### PR TITLE
fixed a bug when connection breaks

### DIFF
--- a/public/bin/shellshare
+++ b/public/bin/shellshare
@@ -82,8 +82,8 @@ def stream_file(path, url, room, password):
                     if success:
                         break
                     else:
-                        conn = httplib.HTTPConnection(url)
                         time.sleep(1)
+                        conn = httplib.HTTPConnection(url)
         error('There was an error connecting to the server.')
     except NotAuthorizedException:
         error('You\'re not authorized to share on http://%s/%s.' % (url, room))

--- a/public/bin/shellshare
+++ b/public/bin/shellshare
@@ -82,6 +82,7 @@ def stream_file(path, url, room, password):
                     if success:
                         break
                     else:
+                        conn = httplib.HTTPConnection(url)
                         time.sleep(1)
         error('There was an error connecting to the server.')
     except NotAuthorizedException:


### PR DESCRIPTION
I have seen this message 

'There was an error connecting to the server.' 

a lot during my sessions. It usually happens after the session has been idle for a short while. When the connection breaks, retry will not help.

With this change a new connection will be created before retrying. I have tested locally and it seems working perfectly.