### PR TITLE
Fix format exception when posting too much data

### DIFF
--- a/public/bin/shellshare
+++ b/public/bin/shellshare
@@ -87,7 +87,7 @@ def stream_file(path, url, room, password):
     except NotAuthorizedException:
         error('You\'re not authorized to share on https://%s/%s.' % (url, room))
     except RequestTooLargeException:
-        error('You\'ve wrote too much too fast. Please, slow down.' % (url, room))
+        error('You\'ve wrote too much too fast. Please, slow down.')
 
 
 def error(*args):


### PR DESCRIPTION
Fixes a TypeError generated on the client-side when too much data is posted at once.

    Unhandled exception in thread started by <function stream_file at 0x7f142fa39488>
    Traceback (most recent call last):
        File "/usr/local/bin/shellshare", line 90, in stream_file
            error('You\'ve wrote too much too fast. Please, slow down.' % (url, room))  
    TypeError: not all arguments converted during string formatting

An easy way to trip this case is to run something that dumps lots of data, like `dmesg`.

It's also possible to avoid generating the 413 Request Entity Too Large error in the first place by limiting the amount of data read and sent in a single post request. For example, in `stream_file`:

    max_post_size = 300 * 1024
    # Url-encoding control characters = 3/1 overhead
    # Base64 encoding = 4/3 overhead
    # Worst case encoded size is 4x the original size
    # Also allow some overhead for the other json fields
    max_unencoded_size = (max_post_size // 4) - 64
    data = f.read(max_unencoded_size)
