### PR TITLE
fix "you've wrote too much too fast" error

### DIFF
--- a/public/bin/shellshare
+++ b/public/bin/shellshare
@@ -85,7 +85,7 @@ def stream_file(path, url, room, password):
             time.sleep(1)
             # osx wants this because EOF is cached
             f.seek(0, os.SEEK_CUR)
-            data = f.read()
+            data = f.read(4096)
             if not (data == ""):
                 urlencoded = urllib_quote(data).encode('utf-8')
                 encoded_str = base64.b64encode(urlencoded).decode('utf-8')


### PR DESCRIPTION
By assigning a buffer length to the f.read() op, you can read arbitrarily-long streams from the shellshare sender.  There will be a 1-second delay between rendering each received buffer.  Line 97 could be adjusted to delay less than a second, if desired.