### PR TITLE
Dockerisation of the server side

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+node_modules
+public/javascript/*.bundle.js
+public/javascript/*.min.js
+public/stylesheet/*.min.css
+ecosystem.json5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM nodesource/node:4.2.5
+
+RUN apt-get update
+RUN apt-get install -y gnupg libkrb5-dev
+RUN curl https://www.mongodb.org/static/pgp/server-4.0.asc | apt-key add -
+RUN echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/4.0 main" | tee /etc/apt/sources.list.d/mongodb-org-4.0.list
+
+RUN apt-get update
+RUN apt-get install -y mongodb-org
+RUN npm install -g gulp-cli
+
+
+COPY . /shellshare/
+
+WORKDIR /shellshare
+RUN mkdir -p /data/db
+RUN npm set unsafe-perm true
+RUN npm install
+CMD ["/shellshare/run_services"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,11 @@ FROM nodesource/node:4.2.5
 
 RUN apt-get update
 RUN apt-get install -y gnupg libkrb5-dev
-RUN curl https://www.mongodb.org/static/pgp/server-4.0.asc | apt-key add -
-RUN echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/4.0 main" | tee /etc/apt/sources.list.d/mongodb-org-4.0.list
-
-RUN apt-get update
-RUN apt-get install -y mongodb-org
 RUN npm install -g gulp-cli
 
 
 COPY . /shellshare/
 
 WORKDIR /shellshare
-RUN mkdir -p /data/db
 RUN npm set unsafe-perm true
 RUN npm install
-CMD ["/shellshare/run_services"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,4 @@ COPY . /shellshare/
 WORKDIR /shellshare
 RUN npm set unsafe-perm true
 RUN npm install
+# HEALTHCHECK --interval=5m30s --timeout=3s CMD curl -f http://localhost:3000/ || exit 1

--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ following:
 ./public/bin/shellshare --server localhost:3000
 ```
 
+### Docker
+
+Alternatively, you could run the server using [docker
+compose](https://docs.docker.com/compose/install/) as follows:
+
+```
+docker-compose up --build
+```
+
+It will build a container with shellshare and all its dependencies, pull the
+latest mongodb container and connect them as needed. If you want to modify any
+of the environment variables or properties, check the
+[`docker-compose.yml`](./docker-compose.yml) file.
+
 ## Limitations
 
 This project is intended for live broadcasts only. If you'd like to record your terminal, check [asciinema.org](https://asciinema.org)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,8 @@ services:
       # - HOST=
     depends_on:
       - mongo
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      interval: 5m30s
+      timeout: 3s
+      retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  mongo:
+    image: mongo
+    ports:
+    - "27017:27017"
+  node:
+    build: .
+    ports:
+      - "3000:3000"
+    working_dir: /shellshare
+    environment:
+      - NODE_ENV=production
+    depends_on:
+      - mongo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - "3000:3000"
     working_dir: /shellshare
     environment:
+      - MONGOLAB_URI=mongodb://mongo:27017/shellshare
       - NODE_ENV=production
+      # - HOST=
     depends_on:
       - mongo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ version: '3'
 services:
   mongo:
     image: mongo
-    ports:
-    - "27017:27017"
+    expose:
+      - "27017"
   node:
     build: .
     ports:

--- a/run_services
+++ b/run_services
@@ -1,3 +1,0 @@
-#!/bin/bash
-/usr/bin/mongod --fork --logpath /var/log/mongod.log --bind_ip 127.0.0.1
-npm start

--- a/run_services
+++ b/run_services
@@ -1,0 +1,3 @@
+#!/bin/bash
+/usr/bin/mongod --fork --logpath /var/log/mongod.log --bind_ip 127.0.0.1
+npm start


### PR DESCRIPTION
And we have a :whale2: !!

It took me a while! I wanted to see how the server runs locally but the newer versions of node were giving me problems. I know very little how node and js works, so maybe there's a way to make it work with a more recent container.

I tried: 
- :x:  [`node:13.12-stretch`](https://hub.docker.com/_/node/?tab=description&page=10) and got too many errors.
- :x: [`cusspvz/node:4.2.6-development`](https://hub.docker.com/r/cusspvz/node) but I couldn't manage to install mongodb :leaves: there... (maybe it could work now that I use docker-compose)
- :heavy_check_mark: [`nodesource/node:4.2.5`](https://hub.docker.com/layers/nodesource/node/4.2.5/images/sha256-5d3e4ba423deca94f6a9c5b8da3c4803f15f91e0a196c7c530d9f471c510c370?context=explore), first all in one container (61fa3f9) with an extra script to make mongodb (v4.0) run together with the application and then using docker-compose (470c0fd).

**Todo**:
- [x] Add some details on how to run it on the `README.md`
