### PR TITLE
Adding User-Agent string to urllib

### DIFF
--- a/public/bin/shellshare
+++ b/public/bin/shellshare
@@ -182,6 +182,9 @@ if platform.system() == 'Windows':
         )
         if should_download.lower() not in {'', 'y', 'yes'}:
             exit(0)
+        opener = url_req.build_opener()
+        opener.addheaders = [('User-Agent', 'Mozilla/5.0')]
+        url_req.install_opener(opener)
         url_req.urlretrieve(script_url, script_path)
 else:
     # Use OS version of script


### PR DESCRIPTION
shellshare.net doesn't like urllib downloads of script.exe by default. Adding a User-Agent header to sidestep this until a server-side fix can be applied.