### PR TITLE
Add `shellshare serve`: share your terminal via a local server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ make lint                      # Both clippy + check
 cargo run -- server            # Start server on 0.0.0.0:3000
 cargo run -- server --port 8080 --host 127.0.0.1
 cargo run -- --server http://localhost:3000  # Run client
+cargo run -- serve             # Share via a local server on localhost:8000
 
 # E2E tests (Python + Playwright)
 # Requires a release binary: the suite starts its own servers from it
@@ -28,7 +29,7 @@ cd e2e && uv sync && uv run pytest -n 10
 
 ## Architecture
 
-**Dual-mode binary**: `shellshare` operates as client (default) or server (`shellshare server`).
+**Dual-mode binary**: `shellshare` operates as client (default) or server (`shellshare server`). `shellshare serve` combines both: it boots the embedded server on a background thread (default `localhost:8000`, configurable via `--host`/`--port`) and runs the client against it, sharing the terminal with no external server.
 
 ### Client (`src/cli/`)
 Multi-threaded design ensures network latency never blocks terminal display:

--- a/e2e/test_cli_serve.py
+++ b/e2e/test_cli_serve.py
@@ -22,6 +22,7 @@ from conftest import (
     CLI_PATH,
     SocketListener,
     _free_port,
+    http_post_message,
     poll_until,
     random_id,
     wait_for_server,
@@ -213,6 +214,18 @@ class TestConfiguration:
             returncode, _, _ = finish(proc)
         assert returncode == 0
 
+    def test_bracketed_ipv6_host(self):
+        """--host '[::1]' must not double-bracket the URL or warn."""
+        port = _free_port()
+        room = f"serve-{random_id()}"
+        proc = start_serve(port, room, "pw", host="[::1]")
+        returncode, _, stderr = finish(proc, "hello")
+        assert returncode == 0, f"CLI failed: {stderr}"
+        assert f"http://[::1]:{port}/r/{room}" in stderr
+        # ::1 is loopback: no exposure warning, and no broadcast errors
+        assert "WARNING" not in stderr
+        assert "ERROR" not in stderr
+
     def test_server_flag_is_ignored_with_warning(self):
         """Passing --server alongside serve warns instead of silently ignoring."""
         port = _free_port()
@@ -230,6 +243,31 @@ class TestConfiguration:
         assert "WARNING: --server is ignored" in stderr
         # It must still broadcast to the local server, not example.com
         assert f"http://127.0.0.1:{port}/r/{room}" in stderr
+
+
+class TestRoomClaiming:
+    """Serve mode claims its room before any output is shared."""
+
+    def test_room_claimed_before_first_output(self):
+        """Once the share URL is printed, nobody else can take the room."""
+        port = _free_port()
+        room = f"serve-{random_id()}"
+        proc = start_serve(port, room, "pw", host="127.0.0.1")
+        try:
+            # The share URL is printed after the claim, so reading it
+            # guarantees the room is already owned
+            line = proc.stderr.readline()
+            assert f"/r/{room}" in line, f"unexpected first stderr line: {line!r}"
+
+            status = http_post_message(
+                f"http://127.0.0.1:{port}", room, "wrong-password", "hijack"
+            )
+            assert status == 401, (
+                f"room was claimable by another password (got {status})"
+            )
+        finally:
+            returncode, _, stderr = finish(proc, "hello")
+        assert returncode == 0, f"CLI failed: {stderr}"
 
 
 class TestErrorHandling:

--- a/e2e/test_cli_serve.py
+++ b/e2e/test_cli_serve.py
@@ -1,0 +1,253 @@
+"""
+E2E Tests for Shellshare CLI - Serve Mode
+
+`shellshare serve` starts a local server and broadcasts the terminal to it,
+so a single command shares the terminal without any external server.
+
+Test categories:
+- Local server lifecycle (starts, serves pages, dies with the CLI)
+- End-to-end broadcasting through the local server
+- Port/host configuration
+- Error handling (port already in use)
+"""
+
+import re
+import socket
+import subprocess
+import urllib.request
+
+import pytest
+
+from conftest import (
+    CLI_PATH,
+    SocketListener,
+    _free_port,
+    poll_until,
+    random_id,
+    wait_for_server,
+)
+
+
+def serve_args(port, room, password, host=None):
+    """Build the argv for `shellshare serve` in stdin mode."""
+    args = [str(CLI_PATH), "serve", "--port", str(port), "--stdin",
+            "-r", room, "-W", password]
+    if host is not None:
+        args.extend(["--host", host])
+    return args
+
+
+def start_serve(port, room, password, host=None):
+    """Start `shellshare serve` with stdin held open; caller must finish it."""
+    return subprocess.Popen(
+        serve_args(port, room, password, host=host),
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def finish(proc, message="", timeout=15):
+    """Send the message, close stdin and wait for the CLI to exit.
+
+    Kills the process on timeout so a hung CLI doesn't leak and hold its
+    port for the rest of the (parallel) test run.
+    """
+    try:
+        stdout, stderr = proc.communicate(input=message, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.communicate()
+        raise
+    return proc.returncode, stdout, stderr
+
+
+def port_open(port):
+    """Check whether something is listening on the port on any loopback.
+
+    The default host is "localhost", which may resolve to 127.0.0.1 or ::1
+    depending on the machine, so probe both families.
+    """
+    for family, addr in ((socket.AF_INET, "127.0.0.1"), (socket.AF_INET6, "::1")):
+        try:
+            with socket.socket(family, socket.SOCK_STREAM) as s:
+                s.settimeout(0.5)
+                if s.connect_ex((addr, port)) == 0:
+                    return True
+        except OSError:
+            continue
+    return False
+
+
+class TestLocalServerLifecycle:
+    """The serve command runs its own HTTP server for the session."""
+
+    def test_serves_viewer_page(self):
+        """While serve is running, the room viewer page is reachable."""
+        port = _free_port()
+        room = f"serve-{random_id()}"
+        proc = start_serve(port, room, "pw", host="127.0.0.1")
+        try:
+            wait_for_server(f"http://127.0.0.1:{port}")
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/r/{room}", timeout=5
+            ) as resp:
+                assert resp.status == 200
+                body = resp.read().decode()
+            assert "<html" in body.lower()
+        finally:
+            returncode, _, stderr = finish(proc)
+        assert returncode == 0, f"CLI failed: {stderr}"
+
+    def test_server_stops_when_cli_exits(self):
+        """The local server must not outlive the CLI process."""
+        port = _free_port()
+        proc = start_serve(port, f"serve-{random_id()}", "pw", host="127.0.0.1")
+        try:
+            wait_for_server(f"http://127.0.0.1:{port}")
+        finally:
+            returncode, _, _ = finish(proc)
+        assert returncode == 0
+        assert poll_until(lambda: not port_open(port), timeout=5), (
+            "local server still listening after CLI exit"
+        )
+
+    def test_prints_local_share_url(self):
+        """The share link should point at the local server."""
+        port = _free_port()
+        room = f"serve-{random_id()}"
+        proc = start_serve(port, room, "pw")
+        returncode, _, stderr = finish(proc, "hello")
+        assert returncode == 0
+        assert f"Sharing terminal in http://localhost:{port}/r/{room}" in stderr
+        assert "End of transmission." in stderr
+
+
+class TestBroadcasting:
+    """Messages stream end-to-end through the local server."""
+
+    def test_message_received_via_local_server(self):
+        """A viewer connected to the local server receives the broadcast."""
+        port = _free_port()
+        room = f"serve-{random_id()}"
+        proc = start_serve(port, room, "pw", host="127.0.0.1")
+        listener = SocketListener(room, server_url=f"http://127.0.0.1:{port}")
+        try:
+            wait_for_server(f"http://127.0.0.1:{port}")
+            listener.connect()
+            proc.stdin.write("hello from serve mode")
+            proc.stdin.flush()
+            received = listener.wait_for_message(
+                timeout=10, containing="hello from serve mode"
+            )
+            assert received is not None, "Message not received via Socket.IO"
+        finally:
+            listener.disconnect()
+            returncode, _, stderr = finish(proc)
+        assert returncode == 0, f"CLI failed: {stderr}"
+
+
+class TestConfiguration:
+    """Host and port are configurable via the CLI."""
+
+    def test_default_port_is_8000(self):
+        """Without --port, serve binds localhost:8000."""
+        if port_open(8000):
+            pytest.skip("port 8000 already in use on this machine")
+        proc = subprocess.Popen(
+            [str(CLI_PATH), "serve", "--stdin", "-r", "default-port", "-W", "pw"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            assert poll_until(lambda: port_open(8000), timeout=10), (
+                "serve did not bind the default port 8000"
+            )
+        finally:
+            returncode, _, stderr = finish(proc)
+        assert returncode == 0, f"CLI failed: {stderr}"
+        assert "http://localhost:8000/r/default-port" in stderr
+
+    def test_custom_host(self):
+        """--host 127.0.0.1 binds and is used in the share URL."""
+        port = _free_port()
+        room = f"serve-{random_id()}"
+        proc = start_serve(port, room, "pw", host="127.0.0.1")
+        try:
+            wait_for_server(f"http://127.0.0.1:{port}")
+        finally:
+            returncode, _, stderr = finish(proc)
+        assert returncode == 0
+        assert f"http://127.0.0.1:{port}/r/{room}" in stderr
+
+    def test_host_0000_share_url_uses_localhost(self):
+        """Binding 0.0.0.0 must not leak an unconnectable URL to the user."""
+        port = _free_port()
+        room = f"serve-{random_id()}"
+        proc = start_serve(port, room, "pw", host="0.0.0.0")
+        try:
+            wait_for_server(f"http://127.0.0.1:{port}")
+        finally:
+            returncode, _, stderr = finish(proc)
+        assert returncode == 0
+        assert f"http://localhost:{port}/r/{room}" in stderr
+        # Exposing the terminal beyond loopback deserves a heads-up
+        assert "WARNING" in stderr
+
+    def test_port_zero_picks_free_port(self):
+        """--port 0 asks the OS for a free port; the URL shows the real one."""
+        room = f"serve-{random_id()}"
+        proc = start_serve(0, room, "pw", host="127.0.0.1")
+        try:
+            # The share URL is the first thing printed to stderr
+            line = proc.stderr.readline()
+            match = re.search(rf"http://127\.0\.0\.1:(\d+)/r/{room}", line)
+            assert match, f"no share URL with a real port in: {line!r}"
+            port = int(match.group(1))
+            assert port != 0
+            assert poll_until(lambda: port_open(port), timeout=5)
+        finally:
+            returncode, _, _ = finish(proc)
+        assert returncode == 0
+
+    def test_server_flag_is_ignored_with_warning(self):
+        """Passing --server alongside serve warns instead of silently ignoring."""
+        port = _free_port()
+        room = f"serve-{random_id()}"
+        proc = subprocess.Popen(
+            serve_args(port, room, "pw", host="127.0.0.1")
+            + ["--server", "https://example.com"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        returncode, _, stderr = finish(proc, "hello")
+        assert returncode == 0
+        assert "WARNING: --server is ignored" in stderr
+        # It must still broadcast to the local server, not example.com
+        assert f"http://127.0.0.1:{port}/r/{room}" in stderr
+
+
+class TestErrorHandling:
+    """Bind failures are reported up front, before sharing starts."""
+
+    def test_port_in_use_fails_fast(self):
+        """If the port is taken, serve exits non-zero with a clear error."""
+        port = _free_port()
+        blocker = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        blocker.bind(("127.0.0.1", port))
+        blocker.listen(1)
+        try:
+            proc = start_serve(port, f"serve-{random_id()}", "pw",
+                               host="127.0.0.1")
+            returncode, _, stderr = finish(proc)
+        finally:
+            blocker.close()
+        assert returncode != 0
+        assert "could not start local server" in stderr
+        # It must fail before claiming to share anything
+        assert "Sharing terminal in" not in stderr

--- a/e2e/test_socketio.py
+++ b/e2e/test_socketio.py
@@ -1100,9 +1100,16 @@ class TestSocketIOEventOrder:
                 all_received.set()
 
         sio.connect(SERVER_URL)
-        sio.emit('join', f'/r/{room_id}')
 
-        assert all_received.wait(timeout=15), f"Not all events received: {events}"
+        # A bare emit has no delivery guarantee and a lost join means zero
+        # events ever arrive. Re-joining is idempotent (same pattern as
+        # SocketListener.connect), so emit and re-emit until confirmed.
+        for _ in range(3):
+            sio.emit('join', f'/r/{room_id}')
+            if all_received.wait(timeout=5):
+                break
+
+        assert all_received.is_set(), f"Not all events received: {events}"
 
         # Document the order of events
         event_types = [e[0] for e in events]
@@ -1819,9 +1826,15 @@ class TestSocketIOLateJoinerHistory:
                 all_received.set()
 
         sio.connect(SERVER_URL)
-        sio.emit('join', f'/r/{room_id}')
 
-        assert all_received.wait(timeout=15), f"Not all events received: {events}"
+        # Same confirmed-join pattern as SocketListener.connect: a lost
+        # join would mean zero events; re-joining is idempotent
+        for _ in range(3):
+            sio.emit('join', f'/r/{room_id}')
+            if all_received.wait(timeout=5):
+                break
+
+        assert all_received.is_set(), f"Not all events received: {events}"
 
         # Verify size comes before message
         event_types = [e[0] for e in events]

--- a/src/cli/http.rs
+++ b/src/cli/http.rs
@@ -66,6 +66,16 @@ impl Client {
         })
     }
 
+    /// Claim the room without sharing any output yet.
+    ///
+    /// A POST with neither message nor size claims the room with our
+    /// password (first caller wins), closing the window where someone
+    /// else could take the name between server start and first output.
+    pub fn claim_room(&self) -> Result<(), HttpError> {
+        let url = format!("{}/{}", self.server_url, self.room_path);
+        self.do_post(&url, &json!({}))
+    }
+
     /// POST a message to the server with retry logic
     pub fn post_message(
         &self,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -89,7 +89,10 @@ pub fn run(args: ClientArgs) -> Result<(), Box<dyn std::error::Error>> {
     let client = http::Client::new(&server, &room_path, &password)?;
 
     if args.claim_room {
-        client.claim_room()?;
+        if let Err(e) = client.claim_room() {
+            eprintln!("ERROR: could not claim room: {e}");
+            std::process::exit(1);
+        }
     }
 
     // Setup Ctrl+C handler for cleanup

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -31,6 +31,9 @@ pub struct ClientArgs {
     pub room: Option<String>,
     pub password: Option<String>,
     pub stdin: bool,
+    /// Claim the room before sharing starts (used by `serve` so nobody
+    /// can take the name between server start and the first broadcast)
+    pub claim_room: bool,
 }
 
 /// Generate a random 18-character alphanumeric room ID
@@ -84,6 +87,10 @@ pub fn run(args: ClientArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     // Create HTTP client
     let client = http::Client::new(&server, &room_path, &password)?;
+
+    if args.claim_room {
+        client.claim_room()?;
+    }
 
     // Setup Ctrl+C handler for cleanup
     let running = Arc::new(AtomicBool::new(true));

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,12 +179,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             // bind() accepts both "::1" and "[::1]"; strip brackets so
             // the loopback check and the URL see the same host
-            let bare_host = host.trim_start_matches('[').trim_end_matches(']');
+            let bare_host = host
+                .strip_prefix('[')
+                .and_then(|h| h.strip_suffix(']'))
+                .unwrap_or(&host);
+            let parsed_ip = bare_host.parse::<std::net::IpAddr>().ok();
             let is_loopback = bare_host.eq_ignore_ascii_case("localhost")
-                || bare_host
-                    .parse::<std::net::IpAddr>()
-                    .is_ok_and(|ip| ip.is_loopback());
-            let is_wildcard = matches!(bare_host, "0.0.0.0" | "::");
+                || parsed_ip.is_some_and(|ip| ip.is_loopback());
+            let is_wildcard = parsed_ip.is_some_and(|ip| ip.is_unspecified());
             if !is_loopback {
                 eprintln!(
                     "WARNING: binding a non-loopback address; anyone who can reach this machine \

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,13 +163,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             runtime.block_on(server::run(&host, port, cleanup_interval, room_ttl))?;
         }
         Some(Commands::Serve { host, port }) => {
-            if cli.server != DEFAULT_SERVER_URL {
+            // No tracing subscriber on purpose: the embedded server's
+            // logs would garble the shared terminal
+            if cli.server.trim_end_matches('/') != DEFAULT_SERVER_URL {
                 eprintln!("WARNING: --server is ignored by 'serve'; broadcasting to the local server");
-            }
-            if !matches!(host.as_str(), "localhost" | "127.0.0.1" | "::1") {
-                eprintln!(
-                    "WARNING: binding a non-loopback address; anyone who can reach this machine can view this terminal"
-                );
             }
 
             let addr = match start_local_server(&host, port) {
@@ -180,19 +177,43 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             };
 
+            // bind() accepts both "::1" and "[::1]"; strip brackets so
+            // the loopback check and the URL see the same host
+            let bare_host = host.trim_start_matches('[').trim_end_matches(']');
+            let is_loopback = bare_host.eq_ignore_ascii_case("localhost")
+                || bare_host
+                    .parse::<std::net::IpAddr>()
+                    .is_ok_and(|ip| ip.is_loopback());
+            let is_wildcard = matches!(bare_host, "0.0.0.0" | "::");
+            if !is_loopback {
+                eprintln!(
+                    "WARNING: binding a non-loopback address; anyone who can reach this machine \
+                     can view this terminal and broadcast their own rooms on this server"
+                );
+                if is_wildcard {
+                    eprintln!(
+                        "Viewers on other machines must replace 'localhost' in the link below \
+                         with this machine's address"
+                    );
+                }
+            }
+
             // Browsers can't reach wildcard addresses; point the client
             // (and the printed share link) at localhost instead. IPv6
             // hosts need brackets in URLs.
-            let url_host = match host.as_str() {
-                "0.0.0.0" | "::" => "localhost".to_string(),
-                h if h.contains(':') => format!("[{h}]"),
-                h => h.to_string(),
+            let url_host = if is_wildcard {
+                "localhost".to_string()
+            } else if bare_host.contains(':') {
+                format!("[{bare_host}]")
+            } else {
+                bare_host.to_string()
             };
             let args = cli::ClientArgs {
                 server: format!("http://{url_host}:{}", addr.port()),
                 room: cli.room,
                 password: cli.password,
                 stdin: cli.stdin,
+                claim_room: true,
             };
             cli::run(args)?;
         }
@@ -203,6 +224,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 room: cli.room,
                 password: cli.password,
                 stdin: cli.stdin,
+                claim_room: false,
             };
             cli::run(args)?;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 //!
 //! Usage:
 //! - `shellshare server` - Run the broadcasting server
+//! - `shellshare serve` - Share your terminal through a local server
 //! - `shellshare` - Run the client (share your terminal)
 
 mod cli;
@@ -14,12 +15,20 @@ use clap::{Parser, Subcommand};
 use tracing::Level;
 use tracing_subscriber::FmtSubscriber;
 
+/// Default public server the client broadcasts to
+const DEFAULT_SERVER_URL: &str = "https://shellshare.net";
+/// How often the server sweeps for abandoned rooms
+const DEFAULT_CLEANUP_INTERVAL_SECS: u64 = 3600;
+/// How long a room may stay inactive before being removed
+const DEFAULT_ROOM_TTL_SECS: u64 = 21600;
+
 /// Shellshare - Live terminal broadcasting
 #[derive(Parser)]
 #[command(name = "shellshare")]
 #[command(author, version, about = "Live terminal broadcasting")]
 #[command(long_about = "Share your terminal session in real-time.\n\n\
     Run without arguments to share your terminal.\n\
+    Run with 'serve' subcommand to share through a local server (no external server needed).\n\
     Run with 'server' subcommand to start the broadcasting server.")]
 #[command(disable_version_flag = true)]
 struct Cli {
@@ -30,7 +39,7 @@ struct Cli {
     command: Option<Commands>,
 
     /// Server URL to connect to
-    #[arg(short, long, default_value = "https://shellshare.net", global = true)]
+    #[arg(short, long, default_value = DEFAULT_SERVER_URL, global = true)]
     server: String,
 
     /// Room name (default: random 18-char alphanumeric)
@@ -59,13 +68,78 @@ enum Commands {
         port: u16,
 
         /// Room cleanup interval in seconds (default: 3600 = 1 hour)
-        #[arg(long, default_value = "3600")]
+        #[arg(long, default_value_t = DEFAULT_CLEANUP_INTERVAL_SECS)]
         cleanup_interval: u64,
 
         /// Room TTL in seconds - rooms inactive for this long are removed (default: 21600 = 6 hours)
-        #[arg(long, default_value = "21600")]
+        #[arg(long, default_value_t = DEFAULT_ROOM_TTL_SECS)]
         room_ttl: u64,
     },
+    /// Share your terminal through a local server (no external server needed)
+    Serve {
+        /// Host to bind the local server to
+        #[arg(short = 'H', long, default_value = "localhost")]
+        host: String,
+
+        /// Port for the local server
+        #[arg(short, long, default_value = "8000")]
+        port: u16,
+    },
+}
+
+/// Start the embedded server on a background thread and wait until it is
+/// bound, so `shellshare serve` can report errors (e.g. port already in
+/// use) before handing the terminal over to the client.
+///
+/// Returns the address actually bound: with `--port 0` the OS picks a free
+/// port, and the client must broadcast to the real one.
+fn start_local_server(host: &str, port: u16) -> Result<std::net::SocketAddr, String> {
+    let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+    let bind_host = host.to_string();
+
+    std::thread::spawn(move || {
+        let runtime = match tokio::runtime::Runtime::new() {
+            Ok(rt) => rt,
+            Err(e) => {
+                let _ = ready_tx.send(Err(e.to_string()));
+                return;
+            }
+        };
+        runtime.block_on(async {
+            let listener = match server::bind(&bind_host, port).await {
+                Ok(listener) => listener,
+                Err(e) => {
+                    let _ = ready_tx.send(Err(e.to_string()));
+                    return;
+                }
+            };
+            match listener.local_addr() {
+                Ok(addr) => {
+                    let _ = ready_tx.send(Ok(addr));
+                }
+                Err(e) => {
+                    let _ = ready_tx.send(Err(e.to_string()));
+                    return;
+                }
+            }
+            if let Err(e) = server::serve_on(
+                listener,
+                DEFAULT_CLEANUP_INTERVAL_SECS,
+                DEFAULT_ROOM_TTL_SECS,
+            )
+            .await
+            {
+                // The client likely holds the terminal in raw mode by now,
+                // so carriage returns keep the message readable
+                eprint!("\r\nERROR: local server stopped: {e}\r\n");
+            }
+        });
+    });
+
+    ready_rx
+        .recv()
+        .unwrap_or_else(|_| Err("server thread exited unexpectedly".to_string()))
+        .map_err(|e| format!("could not start local server on {host}:{port}: {e}"))
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -87,6 +161,40 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             // Create runtime only for server mode
             let runtime = tokio::runtime::Runtime::new()?;
             runtime.block_on(server::run(&host, port, cleanup_interval, room_ttl))?;
+        }
+        Some(Commands::Serve { host, port }) => {
+            if cli.server != DEFAULT_SERVER_URL {
+                eprintln!("WARNING: --server is ignored by 'serve'; broadcasting to the local server");
+            }
+            if !matches!(host.as_str(), "localhost" | "127.0.0.1" | "::1") {
+                eprintln!(
+                    "WARNING: binding a non-loopback address; anyone who can reach this machine can view this terminal"
+                );
+            }
+
+            let addr = match start_local_server(&host, port) {
+                Ok(addr) => addr,
+                Err(e) => {
+                    eprintln!("ERROR: {e}");
+                    std::process::exit(1);
+                }
+            };
+
+            // Browsers can't reach wildcard addresses; point the client
+            // (and the printed share link) at localhost instead. IPv6
+            // hosts need brackets in URLs.
+            let url_host = match host.as_str() {
+                "0.0.0.0" | "::" => "localhost".to_string(),
+                h if h.contains(':') => format!("[{h}]"),
+                h => h.to_string(),
+            };
+            let args = cli::ClientArgs {
+                server: format!("http://{url_host}:{}", addr.port()),
+                room: cli.room,
+                password: cli.password,
+                stdin: cli.stdin,
+            };
+            cli::run(args)?;
         }
         None => {
             // Run client mode

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -69,7 +69,26 @@ pub async fn run(
     cleanup_interval_secs: u64,
     room_ttl_secs: u64,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    info!("Starting shellshare server on {}:{}", host, port);
+    let listener = bind(host, port).await?;
+    serve_on(listener, cleanup_interval_secs, room_ttl_secs).await
+}
+
+/// Bind the server's TCP listener.
+///
+/// Separated from [`serve_on`] so callers (e.g. `shellshare serve`) can
+/// report bind failures before handing the terminal over to the client.
+pub async fn bind(host: &str, port: u16) -> std::io::Result<tokio::net::TcpListener> {
+    tokio::net::TcpListener::bind(format!("{host}:{port}")).await
+}
+
+/// Serve the shellshare app on an already-bound listener
+pub async fn serve_on(
+    listener: tokio::net::TcpListener,
+    cleanup_interval_secs: u64,
+    room_ttl_secs: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let addr = listener.local_addr()?;
+    info!("Starting shellshare server on {}", addr);
     info!(
         "Room cleanup: interval={}s, TTL={}s",
         cleanup_interval_secs, room_ttl_secs
@@ -119,8 +138,7 @@ pub async fn run(
         .layer(TraceLayer::new_for_http());
 
     // Run server
-    let listener = tokio::net::TcpListener::bind(format!("{host}:{port}")).await?;
-    info!("Listening on {}:{}", host, port);
+    info!("Listening on {}", addr);
     axum::serve(listener, app).await?;
 
     Ok(())


### PR DESCRIPTION
## Summary

Adds a `shellshare serve` subcommand: a single command to share your terminal **without an external server**. It boots the embedded broadcasting server on a background thread (default `localhost:8000`, configurable via `--host`/`--port`) and runs the normal terminal-sharing client against it.

- `server::run` split into `bind()` + `serve_on()` so serve mode reports bind failures (e.g. port already in use) before touching the terminal, with exit code 1
- `--port 0` picks a free port; the share URL shows the real bound port
- `0.0.0.0`/`::` map to `localhost` in the share URL; IPv6 hosts are bracketed; binding non-loopback prints a security warning; passing `--server` alongside `serve` warns that it is ignored
- Cleanup defaults are shared constants between `server` and `serve`

## Testing

- New `e2e/test_cli_serve.py` (10 tests): local server lifecycle (dies with the CLI), end-to-end broadcasting through the local server via Socket.IO, host/port configuration, port 0, fail-fast on port conflicts
- Full e2e suite green: 207 passed, 2 skipped
- Pedantic clippy passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)