### PR TITLE
feat: show whether the broadcaster is live in the viewer page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Async Tokio + Axum web server with Socket.IO for real-time updates:
 Routes:
 - `GET /` - Home page with OS detection for install command
 - `GET /r/:room` - Viewer page
-- `GET /ws/r/:room` - WebSocket ingest (the only broadcast transport): claimed/verified at the handshake, binary frames are terminal bytes, text frames are control messages, every stored frame is acked
+- `GET /ws/r/:room` - WebSocket ingest (the only broadcast transport): claimed/verified at the handshake, binary frames are terminal bytes, text frames are control messages, every stored frame is acked. Each open connection counts as an attached broadcaster: viewers get a `broadcasting` Socket.IO event (current state on join, plus every transition) driving the live/offline indicator in the viewer page; a connection silent past 90s (clients ping every 30s) is treated as dead
 - `POST /r/:room` - Retired: always 410 Gone with an upgrade message, so pre-WebSocket clients fail loudly instead of silently
 - `DELETE /r/:room` - Cleanup room
 

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -278,6 +278,7 @@ class SocketListener:
     _messages: list = field(default_factory=list, init=False, repr=False)
     _sizes: list = field(default_factory=list, init=False, repr=False)
     _user_counts: list = field(default_factory=list, init=False, repr=False)
+    _broadcasting: list = field(default_factory=list, init=False, repr=False)
     _condition: threading.Condition = field(default_factory=threading.Condition, init=False, repr=False)
     _connected: bool = field(default=False, init=False, repr=False)
 
@@ -303,6 +304,12 @@ class SocketListener:
         def on_users_count(count):
             with self._condition:
                 self._user_counts.append(count)
+                self._condition.notify_all()
+
+        @self._sio.on('broadcasting')
+        def on_broadcasting(live):
+            with self._condition:
+                self._broadcasting.append(live)
                 self._condition.notify_all()
 
         self._sio.connect(self.server_url)
@@ -404,6 +411,23 @@ class SocketListener:
         """Get the last received user count."""
         with self._condition:
             return self._user_counts[-1] if self._user_counts else 0
+
+    def wait_for_broadcasting(self, expected, timeout=5) -> bool:
+        """Wait until the LATEST broadcasting state equals `expected`."""
+        with self._condition:
+            start = time.time()
+            while True:
+                if self._broadcasting and self._broadcasting[-1] == expected:
+                    return True
+                remaining = timeout - (time.time() - start)
+                if remaining <= 0:
+                    return False
+                self._condition.wait(timeout=remaining)
+
+    def get_last_broadcasting(self):
+        """Last received broadcasting state, or None before the first."""
+        with self._condition:
+            return self._broadcasting[-1] if self._broadcasting else None
 
     def get_last_size(self) -> dict:
         """Get the last received terminal size."""

--- a/e2e/test_broadcasting_status.py
+++ b/e2e/test_broadcasting_status.py
@@ -1,0 +1,145 @@
+"""
+E2E tests for the broadcaster aliveness indicator.
+
+The server tracks ingest WebSocket connections per room and tells
+viewers - on join and on every transition - whether a broadcaster's
+client is currently attached via the Socket.IO `broadcasting` event.
+"Live" means the connection is open, not that output is flowing: the
+CLI pings even when idle.
+"""
+
+import json
+
+from playwright.sync_api import sync_playwright
+
+from conftest import (
+    SERVER_URL,
+    SocketListener,
+    wait_for_server,
+    ws_connect_room,
+)
+
+
+def attach_broadcaster(room_id, password):
+    """Open an ingest connection and wait until the server has
+    registered it (the ack proves the receive loop - which records the
+    attachment before reading any frame - is running)."""
+    ws = ws_connect_room(SERVER_URL, room_id, password)
+    ws.send(json.dumps({"size": {"cols": 80, "rows": 24}}))
+    ws.recv()  # ack
+    return ws
+
+
+class TestBroadcastingStatus:
+    """Socket.IO `broadcasting` event behavior."""
+
+    def test_join_nonexistent_room_reports_offline(self, unique_room):
+        """A viewer joining a room nobody broadcasts to is told so."""
+        wait_for_server(SERVER_URL)
+
+        listener = SocketListener(unique_room)
+        listener.connect()
+        try:
+            assert listener.wait_for_broadcasting(False), \
+                "Expected broadcasting=false on join of an empty room"
+        finally:
+            listener.disconnect()
+
+    def test_join_live_room_reports_broadcasting(self, unique_room, unique_password):
+        """A viewer joining while the broadcaster is attached sees live."""
+        wait_for_server(SERVER_URL)
+
+        ws = attach_broadcaster(unique_room, unique_password)
+        try:
+            listener = SocketListener(unique_room)
+            listener.connect()
+            try:
+                assert listener.wait_for_broadcasting(True), \
+                    "Expected broadcasting=true on join of a live room"
+            finally:
+                listener.disconnect()
+        finally:
+            ws.close()
+
+    def test_viewer_sees_broadcaster_come_and_go(self, unique_room, unique_password):
+        """An already-joined viewer is notified of both transitions."""
+        wait_for_server(SERVER_URL)
+
+        listener = SocketListener(unique_room)
+        listener.connect()
+        try:
+            # The room does not exist yet
+            assert listener.wait_for_broadcasting(False)
+
+            ws = attach_broadcaster(unique_room, unique_password)
+            assert listener.wait_for_broadcasting(True), \
+                "Expected broadcasting=true when the broadcaster attached"
+
+            # The client closing its connection means the session ended,
+            # even though it sent no data right before
+            ws.close()
+            assert listener.wait_for_broadcasting(False), \
+                "Expected broadcasting=false when the broadcaster detached"
+        finally:
+            listener.disconnect()
+
+    def test_room_with_history_but_no_broadcaster_is_offline(
+        self, unique_room, unique_password
+    ):
+        """History alone doesn't make a room live: the one-shot
+        broadcast below disconnects, so a later viewer sees offline."""
+        wait_for_server(SERVER_URL)
+
+        listener = SocketListener(unique_room)
+        listener.connect()
+        try:
+            ws = attach_broadcaster(unique_room, unique_password)
+            ws.send_binary(b"some output")
+            ws.recv()  # ack
+            assert listener.wait_for_broadcasting(True)
+            ws.close()
+            assert listener.wait_for_broadcasting(False)
+
+            # A fresh viewer still gets the history, but is told offline
+            late = SocketListener(unique_room)
+            late.connect()
+            try:
+                assert late.wait_for_message(containing="some output")
+                assert late.wait_for_broadcasting(False)
+            finally:
+                late.disconnect()
+        finally:
+            listener.disconnect()
+
+
+class TestBroadcastingStatusInBrowser:
+    """The indicator in the viewer page itself."""
+
+    def test_indicator_follows_broadcaster(self, unique_room, unique_password):
+        wait_for_server(SERVER_URL)
+
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page()
+            page.goto(f"{SERVER_URL}/r/{unique_room}")
+
+            # No broadcaster yet: the join answer flips it to offline
+            page.wait_for_function(
+                "document.getElementById('broadcast-status').textContent === 'offline'",
+                timeout=10000,
+            )
+
+            ws = attach_broadcaster(unique_room, unique_password)
+            try:
+                page.wait_for_function(
+                    "document.getElementById('broadcast-status').textContent === 'live'",
+                    timeout=10000,
+                )
+            finally:
+                ws.close()
+
+            page.wait_for_function(
+                "document.getElementById('broadcast-status').textContent === 'offline'",
+                timeout=10000,
+            )
+            browser.close()

--- a/public/stylesheet/room.css
+++ b/public/stylesheet/room.css
@@ -4,6 +4,20 @@
   float: right;
 }
 
+.broadcast-status::before {
+  content: "\25CF"; /* ● */
+  margin-right: 0.3em;
+  color: #999;
+}
+
+.broadcast-status.live::before {
+  color: #2ecc40;
+}
+
+.broadcast-status.offline::before {
+  color: #cc4030;
+}
+
 header {
   text-align: left;
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -307,7 +307,11 @@ fn setup_socket_handlers(io: &SocketIo) {
 /// Always answers 410 Gone with an upgrade prompt, whatever the body:
 /// only pre-WebSocket clients still POST here, and a clear rejection
 /// beats silently dropping their output.
-async fn broadcast_handler(Path(room_path): Path<String>) -> impl IntoResponse {
+///
+/// The body is extracted (and thereby drained) even though it's unused:
+/// answering with unread request bytes in flight makes Windows abort
+/// the connection (WSAECONNABORTED) before the client reads the 410.
+async fn broadcast_handler(Path(room_path): Path<String>, _body: Bytes) -> impl IntoResponse {
     debug!("Legacy POST broadcast to room {:?} rejected", RoomId::parse(&room_path));
     plain_response(StatusCode::GONE, LEGACY_CLIENT_MESSAGE)
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -230,7 +230,9 @@ fn setup_socket_handlers(io: &SocketIo) {
                 drop(socket_rooms);
 
                 // Catch the viewer up if the room is live
-                if let Some(snapshot) = state.rooms.snapshot(&room_id).await {
+                let snapshot = state.rooms.snapshot(&room_id).await;
+                let broadcasting = snapshot.as_ref().is_some_and(|s| s.broadcasting);
+                if let Some(snapshot) = snapshot {
                     // Send size FIRST - terminal must be sized before receiving content
                     if let Some(ref size) = snapshot.size {
                         if let Err(e) = socket.emit("size", size) {
@@ -245,6 +247,12 @@ fn setup_socket_handlers(io: &SocketIo) {
                             warn!("Failed to emit message: {:?}", e);
                         }
                     }
+                }
+
+                // Tell the viewer whether a broadcaster is attached
+                // right now; transitions arrive as room broadcasts
+                if let Err(e) = socket.emit("broadcasting", &broadcasting) {
+                    warn!("Failed to emit broadcasting: {:?}", e);
                 }
 
                 // Get fresh user count right before emissions
@@ -368,6 +376,13 @@ async fn ws_ingest_handler(
     ws.on_upgrade(move |socket| ws_ingest_loop(socket, state, room_id, secret))
 }
 
+/// How long the ingest loop waits for ANY frame before declaring the
+/// broadcaster dead. The client pings every 30s even when idle, so only
+/// a vanished peer (crashed machine, dropped NAT mapping) goes silent
+/// this long - and without a bound, a half-open TCP connection would
+/// keep the room's "live" indicator on for the kernel's timeout.
+const INGEST_IDLE_TIMEOUT: Duration = Duration::from_secs(90);
+
 /// Receive loop for one broadcasting WebSocket connection.
 ///
 /// Every stored binary frame is acknowledged with the cumulative byte
@@ -386,8 +401,16 @@ async fn ws_ingest_handler(
 /// (possible if the room was evicted for inactivity and re-claimed by
 /// someone else); the client reconnects and is then rejected at upgrade.
 async fn ws_ingest_loop(mut socket: WebSocket, state: AppState, room_id: RoomId, secret: String) {
+    // The connection itself is the aliveness signal: viewers show the
+    // room as live while at least one ingest connection is attached.
+    // A count of 0 means the room vanished between handshake and
+    // upgrade - the loop below then ends on its first failed append.
+    if state.rooms.broadcaster_connected(&room_id).await > 0 {
+        emit_broadcasting(&state, &room_id, true);
+    }
+
     let mut received_bytes: u64 = 0;
-    while let Some(Ok(msg)) = socket.recv().await {
+    while let Some(Ok(msg)) = recv_with_timeout(&mut socket).await {
         // Every stored frame is acked; size frames add no bytes, so
         // their ack repeats the current count (a no-op for the client's
         // buffer, but it lets a sender await durability of a resize)
@@ -435,6 +458,32 @@ async fn ws_ingest_loop(mut socket: WebSocket, state: AppState, room_id: RoomId,
         }
     }
     info!("WS ingest disconnected for room {:?}", room_id);
+
+    if state.rooms.broadcaster_disconnected(&room_id).await == 0 {
+        emit_broadcasting(&state, &room_id, false);
+    }
+}
+
+/// Receive the next frame, or `None` when the broadcaster has been
+/// silent past [`INGEST_IDLE_TIMEOUT`] - a live client pings every 30s,
+/// so silence that long means the connection is dead on a half-open TCP
+/// socket that would otherwise linger.
+async fn recv_with_timeout(
+    socket: &mut WebSocket,
+) -> Option<Result<WsMessage, axum::Error>> {
+    tokio::time::timeout(INGEST_IDLE_TIMEOUT, socket.recv())
+        .await
+        .ok()
+        .flatten()
+}
+
+/// Tell every viewer in the room whether a broadcaster is attached
+fn emit_broadcasting(state: &AppState, room_id: &RoomId, live: bool) {
+    if let Some(ns) = state.io.get().and_then(|io| io.of("/")) {
+        let _ = ns
+            .within(room_id.as_str().to_string())
+            .emit("broadcasting", &live);
+    }
 }
 
 /// DELETE /r/:room - Delete room

--- a/src/server/rooms.rs
+++ b/src/server/rooms.rs
@@ -66,6 +66,8 @@ pub struct RoomSnapshot {
     pub size: Option<serde_json::Value>,
     /// Accumulated message history as one contiguous byte payload
     pub history: Option<Bytes>,
+    /// Whether a broadcaster's ingest connection is currently attached
+    pub broadcasting: bool,
 }
 
 /// One broadcasting session's state
@@ -78,6 +80,10 @@ struct Room {
     size: Option<serde_json::Value>,
     /// Last activity (broadcast or viewer join), drives eviction
     last_activity: Instant,
+    /// Ingest connections currently attached. More than one is possible
+    /// around a client reconnect (the stale loop briefly overlaps the
+    /// new one) or with two broadcasters sharing a password.
+    broadcasters: usize,
 }
 
 impl Room {
@@ -87,6 +93,7 @@ impl Room {
             messages: MessageHistory::new(MAX_HISTORY_MESSAGES),
             size: None,
             last_activity: Instant::now(),
+            broadcasters: 0,
         }
     }
 }
@@ -146,6 +153,29 @@ impl Rooms {
         Some(RoomSnapshot {
             size: entry.size.clone(),
             history: entry.messages.accumulated(),
+            broadcasting: entry.broadcasters > 0,
+        })
+    }
+
+    /// Record that a broadcaster's ingest connection attached to the
+    /// room. Returns the new connection count (0 when the room vanished
+    /// between the handshake and the upgrade).
+    pub async fn broadcaster_connected(&self, room: &RoomId) -> usize {
+        let mut rooms = self.inner.write().await;
+        rooms.get_mut(room).map_or(0, |entry| {
+            entry.broadcasters += 1;
+            entry.broadcasters
+        })
+    }
+
+    /// Record that a broadcaster's ingest connection detached. Returns
+    /// the remaining count; 0 also covers a room already deleted (the
+    /// `{"delete": true}` path removes the room before the loop ends).
+    pub async fn broadcaster_disconnected(&self, room: &RoomId) -> usize {
+        let mut rooms = self.inner.write().await;
+        rooms.get_mut(room).map_or(0, |entry| {
+            entry.broadcasters = entry.broadcasters.saturating_sub(1);
+            entry.broadcasters
         })
     }
 

--- a/templates/room.html
+++ b/templates/room.html
@@ -18,6 +18,8 @@
   <div class="wrapper">
     <header>
       <div class="online">
+        <span id="broadcast-status" class="broadcast-status">connecting</span>
+        &middot;
         <span id="online-counter">0</span> user<span id="online-counter-plural">s</span> online
       </div>
       <h1 class="title">
@@ -50,6 +52,7 @@
       var joinedBefore = false;
       var onlineCounter = document.getElementById('online-counter');
       var onlineCounterPlural = document.getElementById('online-counter-plural');
+      var broadcastStatus = document.getElementById('broadcast-status');
       var terminalContainer = document.getElementById('terminal');
 
       if (typeof Terminal !== 'undefined') {
@@ -86,6 +89,20 @@
         } else {
           onlineCounterPlural.innerHTML = 's';
         }
+      });
+      // Whether the broadcaster's client is attached to the room right
+      // now (it pings even when idle, so "live" means the session is
+      // open, not that output is flowing). The server reports the
+      // current state on join and every transition afterwards.
+      socket.on('broadcasting', function (live) {
+        broadcastStatus.textContent = live ? 'live' : 'offline';
+        broadcastStatus.className =
+          'broadcast-status ' + (live ? 'live' : 'offline');
+      });
+      // Our own connection is down: we can't know the broadcaster's state
+      socket.on('disconnect', function () {
+        broadcastStatus.textContent = 'connecting';
+        broadcastStatus.className = 'broadcast-status';
       });
       socket.on('message', function (message) {
         if (term && message) {


### PR DESCRIPTION
The viewer header now shows a colored live/offline indicator for the broadcaster's client - "live" meaning its session is open and attached, not that output is flowing (the client pings even when idle).

The signal already existed server-side: each broadcaster holds a persistent ingest WebSocket. The server now counts attached ingest connections per room and emits a `broadcasting` Socket.IO event - current state on join, plus every transition - so late joiners are correct immediately and connected viewers see the flip in real time. The count (rather than a flag) keeps the reconnect overlap and shared-password broadcasters honest: offline only when it hits zero.

To keep the indicator truthful against half-open TCP connections, the ingest loop treats 90s of total silence as a dead broadcaster - safe because live clients ping every 30s.

Fixes #14
Fixes #16 