### PR TITLE
fix: scroll wide terminals horizontally in the viewer instead of clipping

### DIFF
--- a/public/stylesheet/room.css
+++ b/public/stylesheet/room.css
@@ -23,6 +23,21 @@ header {
   overflow: hidden;
 }
 
+/* Terminals wider than the page scroll horizontally instead of
+   wrapping or clipping */
+#terminal {
+  overflow-x: auto;
+}
+
+.terminal {
+  width: max-content;
+  max-width: none;
+}
+
+.terminal > div {
+  white-space: nowrap;
+}
+
 .reverse-video {
   color: #000000;
   background: #ccc;


### PR DESCRIPTION
Broadcasts wider than the page (capped at 1140px) were silently cut off: term.js's float shrank to the page width and overflow: hidden clipped the rest, while hyphens and CJK text could still wrap rows. Let the terminal size to its content (width: max-content), keep every row on one line (white-space: nowrap), and scroll the container horizontally (overflow-x: auto).

Fixes #50