### PR TITLE
Add --theme: broadcast in asciinema's color themes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ rust-embed = { version = "8", features = ["mime-guess", "axum"] }
 mime_guess = "2"
 
 # CLI
-clap = { version = "4", features = ["derive", "env"] }
+clap = { version = "4", features = ["derive", "env", "string"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/e2e/test_cli_tty.py
+++ b/e2e/test_cli_tty.py
@@ -45,6 +45,11 @@ from conftest import (
 )
 
 
+def size_dims(size):
+    """The (cols, rows) of a size message, ignoring extras like theme."""
+    return (size.get("cols"), size.get("rows")) if size else None
+
+
 class TtyCli:
     """Run the shellshare CLI attached to a real controlling TTY.
 
@@ -243,7 +248,7 @@ class TestTtyResize:
             socket_listener, lambda s: "before-resize" in s, timeout=10
         )
         assert poll_until(
-            lambda: socket_listener.get_last_size() == {"cols": 80, "rows": 24},
+            lambda: size_dims(socket_listener.get_last_size()) == (80, 24),
             timeout=5,
         ), f"Initial size wrong: {socket_listener.get_last_size()}"
 
@@ -253,7 +258,7 @@ class TestTtyResize:
         cli.send("echo after-resize\n")
 
         assert poll_until(
-            lambda: socket_listener.get_last_size() == {"cols": 100, "rows": 30},
+            lambda: size_dims(socket_listener.get_last_size()) == (100, 30),
             timeout=10,
         ), (
             "Viewer never received the new size; "

--- a/e2e/test_theme.py
+++ b/e2e/test_theme.py
@@ -1,0 +1,209 @@
+"""
+E2E Tests for the --theme CLI option.
+
+The theme name travels inside the `size` control message (the server
+forwards it verbatim), and the viewer maps it to terminal colors from
+themes.json. These tests cover the wire format, CLI validation, and the
+colors actually rendered in a browser.
+"""
+
+import subprocess
+import time
+
+from playwright.sync_api import sync_playwright, expect
+
+from conftest import CLI_COMMAND, SERVER_URL, SocketListener, random_id
+
+# Background colors from themes.json, as computed CSS values
+DRACULA_BG = "rgb(40, 42, 54)"
+SOLARIZED_LIGHT_BG = "rgb(253, 246, 227)"
+DEFAULT_BG = "rgb(0, 0, 0)"
+
+
+def run_cli_stdin(message, room, password, server=SERVER_URL, extra_args=None, timeout=10):
+    """Run the CLI in stdin mode. Returns (returncode, stdout, stderr)."""
+    args = CLI_COMMAND + ["--stdin", "-s", server, "-r", room, "-W", password]
+    if extra_args:
+        args.extend(extra_args)
+
+    proc = subprocess.Popen(
+        args,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    stdout, stderr = proc.communicate(input=message, timeout=timeout)
+    return proc.returncode, stdout, stderr
+
+
+def terminal_background(page):
+    """The #terminal container's computed background color."""
+    return page.evaluate(
+        "getComputedStyle(document.getElementById('terminal')).backgroundColor"
+    )
+
+
+class TestThemeWireFormat:
+    """The theme must ride inside the size event, verbatim."""
+
+    def test_theme_arrives_in_size_event(self, unique_room, unique_password):
+        listener = SocketListener(unique_room)
+        listener.connect()
+
+        returncode, stdout, stderr = run_cli_stdin(
+            "test", unique_room, unique_password, extra_args=["--theme", "dracula"]
+        )
+        assert returncode == 0, f"CLI failed: {stderr}"
+
+        assert listener.wait_for_size(timeout=5), "No size event received"
+        size = listener.get_last_size()
+        listener.disconnect()
+
+        assert size.get("theme") == "dracula"
+        assert "cols" in size and "rows" in size
+
+    def test_no_theme_flag_sends_no_theme(self, unique_room, unique_password):
+        listener = SocketListener(unique_room)
+        listener.connect()
+
+        returncode, stdout, stderr = run_cli_stdin(
+            "test", unique_room, unique_password
+        )
+        assert returncode == 0, f"CLI failed: {stderr}"
+
+        assert listener.wait_for_size(timeout=5), "No size event received"
+        size = listener.get_last_size()
+        listener.disconnect()
+
+        assert "theme" not in size
+
+
+class TestThemeValidation:
+    """An invalid theme must fail before the room is claimed."""
+
+    def test_unknown_theme_fails_with_available_list(self):
+        proc = subprocess.Popen(
+            CLI_COMMAND + ["--stdin", "--theme", "no-such-theme"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        stdout, stderr = proc.communicate(input="", timeout=10)
+
+        assert proc.returncode != 0
+        assert "no-such-theme" in stderr
+        # The error must list what IS available
+        for theme in ["asciinema", "dracula", "solarized-dark", "tango"]:
+            assert theme in stderr, f"'{theme}' missing from error: {stderr}"
+
+    def test_theme_flag_in_help(self):
+        proc = subprocess.Popen(
+            CLI_COMMAND + ["--help"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        stdout, stderr = proc.communicate(timeout=10)
+        assert "--theme" in stdout + stderr
+
+
+class TestThemeRendering:
+    """The browser must render the broadcast in the chosen colors.
+
+    These use dedicated servers: the shared one on :3000 may be an older
+    binary whose viewer page predates themes.
+    """
+
+    def test_theme_colors_render_in_browser(self, dedicated_server):
+        server = dedicated_server()
+        room_id = f"theme-{random_id()}"
+        password = f"secret-{random_id()}"
+
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page()
+            page.goto(f"{server.url}/r/{room_id}")
+            page.wait_for_selector("#terminal", timeout=10000)
+            page.wait_for_function(
+                "document.getElementById('online-counter').textContent !== '0'",
+                timeout=10000,
+            )
+
+            returncode, stdout, stderr = run_cli_stdin(
+                "themed output", room_id, password, server=server.url,
+                extra_args=["--theme", "dracula"],
+            )
+            assert returncode == 0, f"CLI failed: {stderr}"
+
+            expect(page.locator("#terminal")).to_contain_text(
+                "themed output", timeout=10000
+            )
+            assert terminal_background(page) == DRACULA_BG
+            browser.close()
+
+    def test_late_joiner_sees_theme(self, dedicated_server):
+        """The theme is replayed with the stored size, so a viewer who
+        joins after the broadcast started still gets the colors."""
+        server = dedicated_server()
+        room_id = f"theme-late-{random_id()}"
+        password = f"secret-{random_id()}"
+
+        # The broadcaster must stay alive: the room (and its stored
+        # size+theme) is deleted when the CLI exits
+        proc = subprocess.Popen(
+            CLI_COMMAND + [
+                "--stdin", "-s", server.url, "-r", room_id, "-W", password,
+                "--theme", "solarized-light",
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        try:
+            proc.stdin.write("early content\n")
+            proc.stdin.flush()
+            time.sleep(2)  # let the CLI deliver before the viewer joins
+
+            with sync_playwright() as p:
+                browser = p.chromium.launch()
+                page = browser.new_page()
+                page.goto(f"{server.url}/r/{room_id}")
+                page.wait_for_selector("#terminal", timeout=10000)
+
+                expect(page.locator("#terminal")).to_contain_text(
+                    "early content", timeout=10000
+                )
+                assert terminal_background(page) == SOLARIZED_LIGHT_BG
+                browser.close()
+        finally:
+            proc.stdin.close()
+            proc.wait(timeout=10)
+
+    def test_default_colors_without_theme(self, dedicated_server):
+        server = dedicated_server()
+        room_id = f"theme-default-{random_id()}"
+        password = f"secret-{random_id()}"
+
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page()
+            page.goto(f"{server.url}/r/{room_id}")
+            page.wait_for_selector("#terminal", timeout=10000)
+            page.wait_for_function(
+                "document.getElementById('online-counter').textContent !== '0'",
+                timeout=10000,
+            )
+
+            returncode, stdout, stderr = run_cli_stdin(
+                "plain output", room_id, password, server=server.url
+            )
+            assert returncode == 0, f"CLI failed: {stderr}"
+
+            expect(page.locator("#terminal")).to_contain_text(
+                "plain output", timeout=10000
+            )
+            assert terminal_background(page) == DEFAULT_BG
+            browser.close()

--- a/e2e/test_theme.py
+++ b/e2e/test_theme.py
@@ -17,7 +17,7 @@ from conftest import CLI_COMMAND, SERVER_URL, SocketListener, random_id
 # Background colors from themes.json, as computed CSS values
 DRACULA_BG = "rgb(40, 42, 54)"
 SOLARIZED_LIGHT_BG = "rgb(253, 246, 227)"
-DEFAULT_BG = "rgb(0, 0, 0)"
+TANGO_BG = "rgb(18, 19, 20)"  # the default theme
 
 
 def run_cli_stdin(message, room, password, server=SERVER_URL, extra_args=None, timeout=10):
@@ -63,7 +63,7 @@ class TestThemeWireFormat:
         assert size.get("theme") == "dracula"
         assert "cols" in size and "rows" in size
 
-    def test_no_theme_flag_sends_no_theme(self, unique_room, unique_password):
+    def test_no_theme_flag_defaults_to_tango(self, unique_room, unique_password):
         listener = SocketListener(unique_room)
         listener.connect()
 
@@ -76,7 +76,7 @@ class TestThemeWireFormat:
         size = listener.get_last_size()
         listener.disconnect()
 
-        assert "theme" not in size
+        assert size.get("theme") == "tango"
 
 
 class TestThemeValidation:
@@ -106,7 +106,12 @@ class TestThemeValidation:
             text=True,
         )
         stdout, stderr = proc.communicate(timeout=10)
-        assert "--theme" in stdout + stderr
+        help_text = stdout + stderr
+        assert "--theme" in help_text
+        assert "default: tango" in help_text
+        # The help must list what's available
+        for theme in ["asciinema", "dracula", "solarized-dark", "tango"]:
+            assert theme in help_text, f"'{theme}' missing from help: {help_text}"
 
 
 class TestThemeRendering:
@@ -182,7 +187,7 @@ class TestThemeRendering:
             proc.stdin.close()
             proc.wait(timeout=10)
 
-    def test_default_colors_without_theme(self, dedicated_server):
+    def test_tango_colors_without_theme_flag(self, dedicated_server):
         server = dedicated_server()
         room_id = f"theme-default-{random_id()}"
         password = f"secret-{random_id()}"
@@ -205,5 +210,5 @@ class TestThemeRendering:
             expect(page.locator("#terminal")).to_contain_text(
                 "plain output", timeout=10000
             )
-            assert terminal_background(page) == DEFAULT_BG
+            assert terminal_background(page) == TANGO_BG
             browser.close()

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -31,6 +31,8 @@ pub struct ClientArgs {
     pub room: Option<String>,
     pub password: Option<String>,
     pub stdin: bool,
+    /// Viewer color theme, already validated against `themes::names()`
+    pub theme: Option<String>,
 }
 
 /// Generate a random 18-character alphanumeric room ID
@@ -86,7 +88,8 @@ pub fn run(args: ClientArgs) -> Result<(), Box<dyn std::error::Error>> {
     // a broadcast that can never work is reported before the terminal
     // is handed over to the shell
     let size = get_terminal_size();
-    let transport = match ws::Transport::connect(&server, &room_path, &password, size) {
+    let transport = match ws::Transport::connect(&server, &room_path, &password, size, args.theme)
+    {
         Ok(transport) => transport,
         Err(e) => {
             eprintln!("ERROR: {e}");

--- a/src/cli/ws.rs
+++ b/src/cli/ws.rs
@@ -84,6 +84,10 @@ pub struct Transport {
     size: TermSize,
     /// Size already delivered on the CURRENT connection, if any
     sent_size: Option<TermSize>,
+    /// Viewer color theme, carried inside every size message (the
+    /// server stores and forwards the size verbatim, so late joiners
+    /// get the theme with no server-side knowledge of it)
+    theme: Option<String>,
     backoff: Duration,
     /// Do not attempt to reconnect before this instant
     next_attempt: Option<Instant>,
@@ -100,6 +104,7 @@ impl Transport {
         room_path: &str,
         password: &str,
         size: TermSize,
+        theme: Option<String>,
     ) -> Result<Self, TransportError> {
         let ws_base = if let Some(rest) = server_url.strip_prefix("https://") {
             format!("wss://{rest}")
@@ -122,6 +127,7 @@ impl Transport {
             dropped_unacked: 0,
             size,
             sent_size: None,
+            theme,
             backoff: INITIAL_BACKOFF,
             next_attempt: None,
             last_ping: Instant::now(),
@@ -206,7 +212,11 @@ impl Transport {
 
         // Size first, so viewers resize before the content that follows
         if self.sent_size != Some(self.size) {
-            let frame = Message::text(json!({"size": self.size}).to_string());
+            let mut size = json!(self.size);
+            if let Some(theme) = &self.theme {
+                size["theme"] = json!(theme);
+            }
+            let frame = Message::text(json!({"size": size}).to_string());
             if self.write(frame).is_err() {
                 return Ok(());
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,23 +57,11 @@ struct Cli {
     #[arg(long, global = true)]
     stdin: bool,
 
-    /// Color theme viewers see the broadcast in (default: viewer's default colors)
-    #[arg(short, long, global = true, value_parser = parse_theme)]
+    /// Color theme viewers see the broadcast in
+    // Validated at parse time, so a typo fails before the room is
+    // claimed and the shell spawns.
+    #[arg(short, long, global = true, default_value = "tango", value_parser = clap::builder::PossibleValuesParser::new(themes::names()))]
     theme: Option<String>,
-}
-
-/// Validate `--theme` against the embedded theme list, so a typo fails
-/// before the room is claimed and the shell spawns.
-fn parse_theme(name: &str) -> Result<String, String> {
-    let names = themes::names();
-    if names.iter().any(|n| n == name) {
-        Ok(name.to_string())
-    } else {
-        Err(format!(
-            "unknown theme '{name}'. Available themes: {}",
-            names.join(", ")
-        ))
-    }
 }
 
 #[derive(Subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@
 mod cli;
 mod protocol;
 mod server;
+mod themes;
 
 use clap::{Parser, Subcommand};
 use tracing::Level;
@@ -55,6 +56,24 @@ struct Cli {
     /// Read from stdin instead of spawning a shell
     #[arg(long, global = true)]
     stdin: bool,
+
+    /// Color theme viewers see the broadcast in (default: viewer's default colors)
+    #[arg(short, long, global = true, value_parser = parse_theme)]
+    theme: Option<String>,
+}
+
+/// Validate `--theme` against the embedded theme list, so a typo fails
+/// before the room is claimed and the shell spawns.
+fn parse_theme(name: &str) -> Result<String, String> {
+    let names = themes::names();
+    if names.iter().any(|n| n == name) {
+        Ok(name.to_string())
+    } else {
+        Err(format!(
+            "unknown theme '{name}'. Available themes: {}",
+            names.join(", ")
+        ))
+    }
 }
 
 #[derive(Subcommand)]
@@ -220,6 +239,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 room: cli.room,
                 password: cli.password,
                 stdin: cli.stdin,
+                theme: cli.theme,
             };
             cli::run(args)?;
         }
@@ -230,6 +250,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 room: cli.room,
                 password: cli.password,
                 stdin: cli.stdin,
+                theme: cli.theme,
             };
             cli::run(args)?;
         }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -58,6 +58,10 @@ impl MessageHistory {
 /// Terminal dimensions, as carried in the `size` control message of
 /// broadcast transports and the `size` Socket.IO event the viewer
 /// listens for.
+///
+/// The client may attach extra fields next to `cols`/`rows` - today a
+/// `theme` name (see `themes.rs`) - which ride along verbatim to the
+/// viewer without the server knowing about them.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 pub struct TermSize {
     pub cols: u16,

--- a/src/server/pages.rs
+++ b/src/server/pages.rs
@@ -75,11 +75,17 @@ pub async fn index_handler(headers: HeaderMap) -> impl IntoResponse {
 /// GET /r/:room - Viewer page
 pub async fn room_page_handler(Path(_room): Path<String>) -> impl IntoResponse {
     match Templates::get("room.html") {
-        Some(content) => Response::builder()
-            .status(StatusCode::OK)
-            .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
-            .body(Body::from(content.data.into_owned()))
-            .unwrap(),
+        Some(content) => {
+            // Inline the theme definitions so the viewer can color the
+            // terminal without an extra request
+            let html = String::from_utf8_lossy(&content.data)
+                .replace("{{THEMES_JSON}}", crate::themes::THEMES_JSON);
+            Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
+                .body(Body::from(html))
+                .unwrap()
+        }
         None => template_missing(),
     }
 }

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -1,0 +1,21 @@
+//! Built-in viewer color themes, embedded from `themes.json`.
+//!
+//! The JSON file is the single source of truth: the CLI validates
+//! `--theme` against its keys, and the server injects the file verbatim
+//! into the viewer page (`templates/room.html`), which maps a theme to
+//! term.js colors. Adding a theme means adding one entry to the file.
+//!
+//! A theme is `{foreground, background, palette}` where `palette` holds
+//! the 16 ANSI colors as hex strings, matching asciinema's theme format.
+
+/// Theme definitions, injected verbatim into the viewer page.
+pub const THEMES_JSON: &str = include_str!("../themes.json");
+
+/// The available theme names.
+pub fn names() -> Vec<String> {
+    serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(THEMES_JSON)
+        .expect("themes.json must be a JSON object keyed by theme name")
+        .keys()
+        .cloned()
+        .collect()
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -77,6 +77,8 @@ $ exit</span><span class="windows">PS&gt; # ...
 PS&gt; exit</span>
 <span class="shell-output">End of transmission.</span></code></pre>
         <p>If you don't set a password, shellshare will use your network card's MAC address to uniquely identify your computer. This means you'll be able to transmit to the same room later only if you're using the same computer.</p>
+        <h3>Can I change the colors viewers see?</h3>
+        <p>Yes. Start shellshare with <code>--theme</code> (e.g. <code>./shellshare --theme dracula</code>) and viewers will see your broadcast in that color scheme. We support the same themes as <a href="https://docs.asciinema.org/manual/player/themes/">asciinema</a>: <code>asciinema</code>, <code>dracula</code>, <code>gruvbox-dark</code>, <code>monokai</code>, <code>nord</code>, <code>seti</code>, <code>solarized-dark</code>, <code>solarized-light</code> and <code>tango</code>.</p>
         <h3>Can I recover the password to a custom room?</h3>
         <p>No. However, the rooms are deleted after a day of inactivity, so you can recreate it in 24 hours.</p>
         <h3>Can I run shellshare on Windows?</h3>

--- a/templates/room.html
+++ b/templates/room.html
@@ -40,6 +40,8 @@
     (function () {
       'use strict';
 
+      // Theme definitions injected by the server from themes.json
+      var THEMES = {{THEMES_JSON}};
       var socket = io();
       var room = window.location.pathname;
       var term;
@@ -101,18 +103,28 @@
         }
 
         sizeChanged = (currentSize.cols != size.cols ||
-                       currentSize.rows != size.rows);
+                       currentSize.rows != size.rows ||
+                       currentSize.theme != size.theme);
 
         if (term && sizeChanged) {
           term.destroy();
         }
 
         if (typeof Terminal !== 'undefined' && (!term || sizeChanged)) {
-          term = new Terminal({
+          var options = {
             cols: size.cols,
             rows: size.rows,
             body: terminalContainer,
-          });
+          };
+          var theme = THEMES[size.theme];
+          if (theme) {
+            // term.js takes the 16 ANSI colors plus background and
+            // foreground as the last two entries
+            options.colors = theme.palette.concat([theme.background,
+                                                   theme.foreground]);
+            terminalContainer.style.backgroundColor = theme.background;
+          }
+          term = new Terminal(options);
           term.open();
         }
 

--- a/themes.json
+++ b/themes.json
@@ -1,0 +1,92 @@
+{
+  "asciinema": {
+    "foreground": "#cccccc",
+    "background": "#121314",
+    "palette": [
+      "#000000", "#dd3c69", "#4ebf22", "#ddaf3c",
+      "#26b0d7", "#b954e1", "#54e1b9", "#d9d9d9",
+      "#4d4d4d", "#dd3c69", "#4ebf22", "#ddaf3c",
+      "#26b0d7", "#b954e1", "#54e1b9", "#ffffff"
+    ]
+  },
+  "dracula": {
+    "foreground": "#f8f8f2",
+    "background": "#282a36",
+    "palette": [
+      "#21222c", "#ff5555", "#50fa7b", "#f1fa8c",
+      "#bd93f9", "#ff79c6", "#8be9fd", "#f8f8f2",
+      "#6272a4", "#ff6e6e", "#69ff94", "#ffffa5",
+      "#d6acff", "#ff92df", "#a4ffff", "#ffffff"
+    ]
+  },
+  "gruvbox-dark": {
+    "foreground": "#fbf1c7",
+    "background": "#282828",
+    "palette": [
+      "#282828", "#cc241d", "#98971a", "#d79921",
+      "#458588", "#b16286", "#689d6a", "#a89984",
+      "#7c6f65", "#fb4934", "#b8bb26", "#fabd2f",
+      "#83a598", "#d3869b", "#8ec07c", "#fbf1c7"
+    ]
+  },
+  "monokai": {
+    "foreground": "#f8f8f2",
+    "background": "#272822",
+    "palette": [
+      "#272822", "#f92672", "#a6e22e", "#f4bf75",
+      "#66d9ef", "#ae81ff", "#a1efe4", "#f8f8f2",
+      "#75715e", "#f92672", "#a6e22e", "#f4bf75",
+      "#66d9ef", "#ae81ff", "#a1efe4", "#f9f8f5"
+    ]
+  },
+  "nord": {
+    "foreground": "#eceff4",
+    "background": "#2e3440",
+    "palette": [
+      "#3b4252", "#bf616a", "#a3be8c", "#ebcb8b",
+      "#81a1c1", "#b48ead", "#88c0d0", "#eceff4",
+      "#3b4252", "#bf616a", "#a3be8c", "#ebcb8b",
+      "#81a1c1", "#b48ead", "#88c0d0", "#eceff4"
+    ]
+  },
+  "seti": {
+    "foreground": "#cacecd",
+    "background": "#111213",
+    "palette": [
+      "#323232", "#c22832", "#8ec43d", "#e0c64f",
+      "#43a5d5", "#8b57b5", "#8ec43d", "#eeeeee",
+      "#323232", "#c22832", "#8ec43d", "#e0c64f",
+      "#43a5d5", "#8b57b5", "#8ec43d", "#ffffff"
+    ]
+  },
+  "solarized-dark": {
+    "foreground": "#839496",
+    "background": "#002b36",
+    "palette": [
+      "#073642", "#dc322f", "#859900", "#b58900",
+      "#268bd2", "#d33682", "#2aa198", "#eee8d5",
+      "#002b36", "#cb4b16", "#586e75", "#657b83",
+      "#839496", "#6c71c4", "#93a1a1", "#fdf6e3"
+    ]
+  },
+  "solarized-light": {
+    "foreground": "#657b83",
+    "background": "#fdf6e3",
+    "palette": [
+      "#073642", "#dc322f", "#859900", "#b58900",
+      "#268bd2", "#d33682", "#2aa198", "#eee8d5",
+      "#002b36", "#cb4b16", "#586e75", "#657c83",
+      "#839496", "#6c71c4", "#93a1a1", "#fdf6e3"
+    ]
+  },
+  "tango": {
+    "foreground": "#cccccc",
+    "background": "#121314",
+    "palette": [
+      "#000000", "#cc0000", "#4e9a06", "#c4a000",
+      "#3465a4", "#75507b", "#06989a", "#d3d7cf",
+      "#555753", "#ef2929", "#8ae234", "#fce94f",
+      "#729fcf", "#ad7fa8", "#34e2e2", "#eeeeec"
+    ]
+  }
+}


### PR DESCRIPTION
Viewers see the terminal in a color scheme chosen by the broadcaster via --theme (works with `serve` too). The nine asciinema-player themes are supported; themes.json is the single source of truth, so adding a theme is one JSON entry.

The theme name rides inside the existing `size` control message, which the server already stores and forwards verbatim: no server-side protocol changes, late joiners get the theme via the normal size replay, and new clients stay compatible with old servers. The viewer maps the theme to term.js's colors option (16 ANSI colors + bg + fg).

Fixes #69