### PR TITLE
Distribute shellshare on npm (npx shellshare)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,3 +258,47 @@ jobs:
             assets/shellshare-macos-x86_64
             assets/shellshare-macos-aarch64
           generate_release_notes: true
+
+  # Publish to npm so `npx shellshare` works: four platform packages carrying
+  # the binaries (esbuild-style optionalDependencies, no postinstall) plus the
+  # meta package with the launcher shim. Auth via npm Trusted Publishing (OIDC).
+  publish-npm:
+    needs: [release]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Download embedded binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: 'shellshare-*'
+          path: npm-binaries
+
+      - name: Stage npm packages
+        run: node npm/scripts/prepare-packages.js "${GITHUB_REF_NAME#v}" npm-binaries dist-npm
+
+      - name: Smoke-test the Linux package binary
+        run: dist-npm/shellshare-linux-x64/bin/shellshare --version
+
+      # Platform packages first so the meta package never points at versions
+      # that don't exist yet. The shellshare-* glob skips the meta dir.
+      - name: Publish platform packages
+        run: |
+          for dir in dist-npm/shellshare-*; do
+            (cd "$dir" && npm publish --provenance --access public)
+          done
+
+      - name: Publish meta package
+        run: cd dist-npm/shellshare && npm publish --provenance --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,6 +280,10 @@ jobs:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
+      # OIDC Trusted Publishing needs npm >= 11.5; Node 22 bundles npm 10
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - name: Download embedded binaries
         uses: actions/download-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Copy and paste the following line in your terminal:
 curl -sLo shellshare https://get.shellshare.net/ && chmod +x shellshare && ./shellshare
 ```
 
+If you have Node.js, you can also run it with no manual download on Linux, macOS, or Windows:
+
+```bash
+npx shellshare
+```
+
 You'll see a line saying `Sharing session in
 https://shellshare.net/r/h2Uont4F8bvZ8VDjHb` (your link will be different).
 Anyone that opens this link will be able to see what you're doing in your

--- a/npm/platform-packages.json
+++ b/npm/platform-packages.json
@@ -17,7 +17,7 @@
     "os": "darwin",
     "cpu": "arm64"
   },
-  "shellshare-win32-x64": {
+  "shellshare-windows-x64": {
     "artifact": "shellshare-windows-x86_64",
     "binary": "shellshare.exe",
     "os": "win32",

--- a/npm/platform-packages.json
+++ b/npm/platform-packages.json
@@ -1,0 +1,26 @@
+{
+  "shellshare-linux-x64": {
+    "artifact": "shellshare-linux-x86_64",
+    "binary": "shellshare",
+    "os": "linux",
+    "cpu": "x64"
+  },
+  "shellshare-darwin-x64": {
+    "artifact": "shellshare-macos-x86_64",
+    "binary": "shellshare",
+    "os": "darwin",
+    "cpu": "x64"
+  },
+  "shellshare-darwin-arm64": {
+    "artifact": "shellshare-macos-aarch64",
+    "binary": "shellshare",
+    "os": "darwin",
+    "cpu": "arm64"
+  },
+  "shellshare-win32-x64": {
+    "artifact": "shellshare-windows-x86_64",
+    "binary": "shellshare.exe",
+    "os": "win32",
+    "cpu": "x64"
+  }
+}

--- a/npm/scripts/prepare-packages.js
+++ b/npm/scripts/prepare-packages.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// Stage the npm packages for a release.
+//
+// Usage: node npm/scripts/prepare-packages.js <version> <binaries-dir> <out-dir>
+//
+// <binaries-dir> is the actions/download-artifact@v4 output: one directory
+// per artifact (e.g. shellshare-linux-x86_64/shellshare). Produces in
+// <out-dir> one publishable directory per platform package plus the meta
+// package, all stamped with <version> and the meta package's
+// optionalDependencies pinned exactly to it.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const [version, binariesDir, outDir] = process.argv.slice(2);
+if (!version || !binariesDir || !outDir) {
+  console.error('usage: prepare-packages.js <version> <binaries-dir> <out-dir>');
+  process.exit(1);
+}
+
+const npmDir = path.join(__dirname, '..');
+const platforms = JSON.parse(fs.readFileSync(path.join(npmDir, 'platform-packages.json'), 'utf8'));
+
+// Sanity floor: a real shellshare binary is several MB; anything under 1 MB
+// means we staged the wrong file and must not publish.
+const MIN_BINARY_BYTES = 1024 * 1024;
+
+for (const [name, info] of Object.entries(platforms)) {
+  const src = path.join(binariesDir, info.artifact, info.binary);
+  const size = fs.statSync(src).size;
+  if (size < MIN_BINARY_BYTES) {
+    console.error(`${src} is only ${size} bytes - refusing to package it`);
+    process.exit(1);
+  }
+
+  const pkgDir = path.join(outDir, name);
+  fs.mkdirSync(path.join(pkgDir, 'bin'), { recursive: true });
+  fs.copyFileSync(src, path.join(pkgDir, 'bin', info.binary));
+  fs.chmodSync(path.join(pkgDir, 'bin', info.binary), 0o755);
+  fs.writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify(
+      {
+        name,
+        version,
+        description: `shellshare binary for ${info.os} ${info.cpu}`,
+        os: [info.os],
+        cpu: [info.cpu],
+        files: [`bin/${info.binary}`],
+        license: 'Apache-2.0',
+        repository: { type: 'git', url: 'git+https://github.com/vitorbaptista/shellshare.git' },
+        homepage: 'https://shellshare.net',
+      },
+      null,
+      2,
+    ) + '\n',
+  );
+  console.log(`staged ${name}@${version} (${(size / 1024 / 1024).toFixed(1)} MB)`);
+}
+
+const metaSrc = path.join(npmDir, 'shellshare');
+const metaDir = path.join(outDir, 'shellshare');
+fs.mkdirSync(path.join(metaDir, 'bin'), { recursive: true });
+fs.copyFileSync(path.join(metaSrc, 'bin', 'shellshare.js'), path.join(metaDir, 'bin', 'shellshare.js'));
+fs.chmodSync(path.join(metaDir, 'bin', 'shellshare.js'), 0o755);
+fs.copyFileSync(path.join(metaSrc, 'README.md'), path.join(metaDir, 'README.md'));
+
+const meta = JSON.parse(fs.readFileSync(path.join(metaSrc, 'package.json'), 'utf8'));
+meta.version = version;
+meta.optionalDependencies = Object.fromEntries(Object.keys(platforms).map((name) => [name, version]));
+fs.writeFileSync(path.join(metaDir, 'package.json'), JSON.stringify(meta, null, 2) + '\n');
+console.log(`staged shellshare@${version} (meta package)`);

--- a/npm/shellshare/README.md
+++ b/npm/shellshare/README.md
@@ -1,0 +1,20 @@
+# shellshare
+
+Live terminal broadcasting. Share your terminal session via a web link with a single command.
+
+```bash
+npx shellshare
+```
+
+This prints a link like `https://shellshare.net/r/EPbZJ7VZNakS9vwUlS`. Everything you type is broadcast live to anyone watching that page, read-only, until you exit the shell (Ctrl+D).
+
+Or install it globally:
+
+```bash
+npm install -g shellshare
+shellshare
+```
+
+This package is a thin launcher around the prebuilt `shellshare` binary for your platform (Linux x64, macOS x64/arm64, Windows x64), fetched automatically through npm's `optionalDependencies` — no postinstall scripts.
+
+Docs, FAQ and other install methods: [shellshare.net](https://shellshare.net) · Source: [github.com/vitorbaptista/shellshare](https://github.com/vitorbaptista/shellshare)

--- a/npm/shellshare/bin/shellshare.js
+++ b/npm/shellshare/bin/shellshare.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+// Thin launcher: resolves the platform-specific package (installed via
+// optionalDependencies) and execs the real shellshare binary with the
+// terminal's stdio inherited, so raw mode, Ctrl+C and resize pass through.
+'use strict';
+
+const { spawnSync } = require('child_process');
+
+const PLATFORMS = {
+  'linux x64': 'shellshare-linux-x64',
+  'darwin x64': 'shellshare-darwin-x64',
+  'darwin arm64': 'shellshare-darwin-arm64',
+  'win32 x64': 'shellshare-win32-x64',
+};
+
+const key = process.platform + ' ' + process.arch;
+const pkg = PLATFORMS[key];
+if (!pkg) {
+  console.error('shellshare: unsupported platform: ' + key);
+  console.error('Supported platforms: ' + Object.keys(PLATFORMS).join(', '));
+  console.error('Prebuilt binaries for other setups: https://github.com/vitorbaptista/shellshare/releases');
+  process.exit(1);
+}
+
+const exe = process.platform === 'win32' ? 'shellshare.exe' : 'shellshare';
+let binPath;
+try {
+  binPath = require.resolve(pkg + '/bin/' + exe);
+} catch (err) {
+  console.error('shellshare: the platform package "' + pkg + '" is not installed.');
+  console.error('This usually means optional dependencies were skipped. Reinstall with:');
+  console.error('  npm install -g shellshare --force --include=optional');
+  process.exit(1);
+}
+
+const result = spawnSync(binPath, process.argv.slice(2), { stdio: 'inherit' });
+if (result.error) {
+  console.error('shellshare: failed to start ' + binPath + ': ' + result.error.message);
+  process.exit(1);
+}
+if (result.signal) {
+  // Re-raise so the parent sees the same termination signal.
+  process.kill(process.pid, result.signal);
+} else {
+  process.exit(result.status === null ? 1 : result.status);
+}

--- a/npm/shellshare/bin/shellshare.js
+++ b/npm/shellshare/bin/shellshare.js
@@ -10,7 +10,8 @@ const PLATFORMS = {
   'linux x64': 'shellshare-linux-x64',
   'darwin x64': 'shellshare-darwin-x64',
   'darwin arm64': 'shellshare-darwin-arm64',
-  'win32 x64': 'shellshare-win32-x64',
+  // "windows" not "win32": npm's spam filter rejects new win32-* names
+  'win32 x64': 'shellshare-windows-x64',
 };
 
 const key = process.platform + ' ' + process.arch;

--- a/npm/shellshare/package.json
+++ b/npm/shellshare/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "shellshare",
+  "version": "0.0.0-dev",
+  "description": "Live terminal broadcasting - share your terminal via a web link",
+  "bin": {
+    "shellshare": "bin/shellshare.js"
+  },
+  "files": [
+    "bin/shellshare.js"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vitorbaptista/shellshare.git"
+  },
+  "homepage": "https://shellshare.net",
+  "keywords": [
+    "terminal",
+    "broadcast",
+    "shell",
+    "live",
+    "tty"
+  ],
+  "engines": {
+    "node": ">=14"
+  },
+  "optionalDependencies": {}
+}

--- a/public/stylesheet/index.css
+++ b/public/stylesheet/index.css
@@ -29,6 +29,12 @@
   margin: 4em 0;
 }
 
+.instructions .alt-install {
+  text-align: center;
+  margin: -3em 0 4em;
+  color: #888;
+}
+
 .main h2 {
   text-transform: uppercase;
   font-size: 2em;

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,6 +41,7 @@
             <label for="os-windows"><i class="fa fa-2x fa-windows"></i></label>
           </nav>
         </div>
+        <p class="alt-install">Have Node.js? Just run <code>npx shellshare</code></p>
         <h3>What is it?</h3>
         <p>Shellshare allows you to broadcast your terminal live with a single command.</p>
         <h3>How to use?</h3>
@@ -82,6 +83,8 @@ PS&gt; exit</span>
         <h3>Can I run shellshare on Windows?</h3>
         <p>Yes. We have pre-built binaries for Linux, macOS (Intel and Apple Silicon), and Windows. When you download from <a href="https://get.shellshare.net">https://get.shellshare.net</a>, we automatically detect your operating system and give you the correct binary.</p>
         <p>You can also pass the <code>os</code> query parameter to explicitly download a specific binary. The options are <code>linux</code>, <code>windows</code>, <code>mac</code> and <code>mac-arm</code>. For example, if you want to download the Linux binary regardless of your operating system, access <a href="https://get.shellshare.net/?os=linux">https://get.shellshare.net/?os=linux</a>.</p>
+        <h3>Can I install it with npm?</h3>
+        <p>Yes. If you have Node.js, <code>npx shellshare</code> runs it without installing anything by hand, and <code>npm install -g shellshare</code> installs it permanently. The <a href="https://www.npmjs.com/package/shellshare">npm package</a> ships the same prebuilt binaries as the downloads above.</p>
         <h3>Can I self-host shellshare?</h3>
         <p>Yes. The shellshare binary also includes the server. You can start it by running <code>shellshare serve</code> and accessing the server at <a href="http://localhost:3000">http://localhost:3000</a>. No data leaves your computer. I suggest <a href="https://ngrok.com">ngrok</a> as an easy way to allow other people to access your server.</p>
         <h3>I found a problem! What do I do?</h3>


### PR DESCRIPTION
## Summary

Adds npm as a distribution channel so `npx shellshare` runs the tool with zero manual download on Linux, macOS, and Windows, and `npm install -g shellshare` installs it permanently. npm was chosen as the first OS-independent channel because it has by far the widest reach (npm is on ~57% of developer machines per the Stack Overflow 2025 survey, vs ~10% for uv/uvx and ~14% for cargo) and `npx` covers the one-off "just run it now" use case that matches shellshare.

## How it works

The esbuild/Biome pattern — no postinstall scripts:

- Four platform packages (`shellshare-linux-x64`, `shellshare-darwin-x64`, `shellshare-darwin-arm64`, `shellshare-windows-x64`) carry the prebuilt binaries, gated by `os`/`cpu` fields so npm downloads only the matching one.
- The `shellshare` meta package contains a dependency-free launcher shim that resolves the platform package and spawns the binary with `stdio: 'inherit'`, preserving raw TTY mode, Ctrl+C, and SIGWINCH resize.
- A new `publish-npm` job in `release.yml` runs after the GitHub release on `v*` tags: it stages the same embedded binaries the release ships (`npm/scripts/prepare-packages.js` stamps versions from the tag and refuses binaries under 1 MB), smoke-tests the Linux binary, and publishes all five packages via npm Trusted Publishing (OIDC) with `--provenance` — no token secrets.
- Home page and README mention `npx shellshare` as a secondary install path; `curl get.shellshare.net` stays the headline.

The Windows package is named `shellshare-windows-x64` (not `win32`) because npm's spam detection rejects new unscoped `win32-*` names.

## Already done outside this PR

- All five packages published manually at v2.0.5 and verified: `npx -y shellshare@2.0.5 --version` works from the public registry.
- Trusted Publishers configured on npmjs.com for all five packages (repo `vitorbaptista/shellshare`, workflow `release.yml`).

After merging, the next `git tag vX.Y.Z && git push --tags` publishes to npm automatically.

## Test plan

- [x] `make lint` passes
- [x] Staging script tested with real release binaries (version stamping, lockstep optionalDependencies, size guard)
- [x] Shim tested end-to-end: resolves platform package, forwards args/exit codes, clear errors on unsupported platform and missing optional deps
- [x] Published v2.0.5 from the staged output and verified `npx shellshare@2.0.5 --version` on Linux
- [ ] After first CI-tagged release: verify `npx shellshare` on macOS and Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)