### PR TITLE
Add make release for one-command releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-.PHONY: build lint benchmark deploy
+.PHONY: build lint benchmark deploy release
 
 build:
 	cargo build --release
@@ -23,3 +23,8 @@ benchmark:
 
 deploy:
 	git push dokku master:master
+
+# make release            -> bump patch (2.0.6 -> 2.0.7), tag, push; CI does the rest
+# make release VERSION=x.y.z
+release:
+	scripts/release.sh $(VERSION)

--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ dokku builder-dockerfile:set shellshare dockerfile-path Dockerfile.production
 make deploy
 ```
 
+## Releasing
+
+```bash
+make release                # patch bump, e.g. 2.0.6 -> 2.0.7
+make release VERSION=2.1.0  # explicit version
+```
+
+This bumps Cargo.toml, commits, tags, and pushes. CI then runs the e2e tests, builds all platforms, creates the GitHub release with binaries, and publishes the [npm packages](https://www.npmjs.com/package/shellshare).
+
 ## Limitations
 
 This project is intended for live broadcasts only. If you'd like to record your terminal, check [asciinema.org](https://asciinema.org)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Release a new version: bump Cargo.toml, commit, tag, push.
+# The tag push triggers .github/workflows/release.yml, which runs e2e tests,
+# builds all platforms, creates the GitHub release, and publishes to npm.
+#
+# Usage:
+#   scripts/release.sh           # bump patch version (2.0.6 -> 2.0.7)
+#   scripts/release.sh 2.1.0     # release an explicit version
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$branch" != "master" ]; then
+  echo "error: releases must be cut from master (currently on $branch)" >&2
+  exit 1
+fi
+if [ -n "$(git status --porcelain)" ]; then
+  echo "error: working tree is not clean" >&2
+  exit 1
+fi
+
+git pull --ff-only origin master
+
+current=$(grep -m1 '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+
+if [ $# -ge 1 ]; then
+  version=$1
+  if ! [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "error: version must be X.Y.Z, got '$version'" >&2
+    exit 1
+  fi
+else
+  IFS=. read -r major minor patch <<<"$current"
+  version="$major.$minor.$((patch + 1))"
+fi
+
+if git rev-parse "v$version" >/dev/null 2>&1; then
+  echo "error: tag v$version already exists" >&2
+  exit 1
+fi
+
+echo "Releasing $current -> $version"
+sed -i "0,/^version = \"$current\"/s//version = \"$version\"/" Cargo.toml
+cargo check --quiet  # refresh Cargo.lock
+
+git commit -am "chore: release v$version"
+git tag "v$version"
+git push --atomic origin master "v$version"
+
+echo
+echo "v$version pushed. CI takes it from here:"
+echo "  https://github.com/vitorbaptista/shellshare/actions/workflows/release.yml"


### PR DESCRIPTION
## Summary

`make release` is now the single release command:

- `make release` — bump patch version (e.g. 2.0.6 → 2.0.7)
- `make release VERSION=2.1.0` — explicit version

The script (`scripts/release.sh`) guards the invariants: must be on a clean, up-to-date master; the tag must not exist; version must be X.Y.Z. Then it bumps Cargo.toml, refreshes Cargo.lock via `cargo check`, commits `chore: release vX.Y.Z`, tags, and pushes commit + tag atomically. CI takes it from there: e2e tests → all platform builds → GitHub release with binaries → npm publish of all five packages.

This keeps Cargo.toml and the tag in lockstep, eliminating the version-mismatch footgun where the npm package version and `shellshare --version` could disagree.

## Test plan

- [x] `bash -n` syntax check
- [x] Version parse + patch bump logic verified (2.0.6 → 2.0.7)
- [x] sed replaces only the `[package]` version line in Cargo.toml (verified single replacement on a copy)
- [ ] First real use: `make release` to cut v2.0.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)