### PR TITLE
Add fullscreen mode to the web viewer

### DIFF
--- a/e2e/test_broadcast.py
+++ b/e2e/test_broadcast.py
@@ -424,6 +424,76 @@ def test_resize_rebuilds_browser_terminal():
         browser.close()
 
 
+def test_fullscreen_mode_scales_and_restores():
+    """
+    Pressing `f` enters fullscreen: #terminal gets the `fullscreen`
+    class and the font is rescaled to fit the viewport. Pressing `f`
+    again restores the default layout. The class is the primary signal
+    so the test holds even if headless denies native fullscreen.
+    """
+    from conftest import broadcast_message
+
+    room_id = f"test-{random_id()}"
+    password = f"secret-{random_id()}"
+
+    wait_for_server(SERVER_URL)
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(f"{SERVER_URL}/r/{room_id}")
+        page.wait_for_selector("#terminal", timeout=10000)
+        page.wait_for_function(
+            "document.getElementById('online-counter').textContent !== '0'",
+            timeout=10000
+        )
+
+        status = broadcast_message(
+            SERVER_URL, room_id, password, "fullscreen test",
+            size={"cols": 80, "rows": 24},
+        )
+        assert status == 200
+        page.wait_for_function(
+            "document.querySelectorAll('#terminal .terminal').length === 1",
+            timeout=10000,
+        )
+
+        page.keyboard.press("f")
+        page.wait_for_function(
+            "document.getElementById('terminal')"
+            ".classList.contains('fullscreen')",
+            timeout=10000,
+        )
+        # DOM contract preserved: term.js element still the only .terminal
+        assert page.evaluate(
+            "document.querySelectorAll('#terminal .terminal').length === 1"
+        )
+        # Font rescaled to fill the viewport
+        page.wait_for_function(
+            "document.querySelector('#terminal .terminal')"
+            ".style.fontSize !== ''",
+            timeout=10000,
+        )
+        font_size = page.evaluate(
+            "document.querySelector('#terminal .terminal').style.fontSize"
+        )
+        # An 80x24 terminal in a larger viewport must scale up
+        assert font_size.endswith("px") and float(font_size[:-2]) > 14
+
+        page.keyboard.press("f")
+        page.wait_for_function(
+            "!document.getElementById('terminal')"
+            ".classList.contains('fullscreen')",
+            timeout=10000,
+        )
+        assert page.evaluate(
+            "document.querySelector('#terminal .terminal')"
+            ".style.fontSize === ''"
+        )
+
+        browser.close()
+
+
 if __name__ == "__main__":
     test_happy_path_broadcast_appears_in_browser()
     test_user_counter_shows_in_browser()
@@ -432,3 +502,4 @@ if __name__ == "__main__":
     test_late_joiner_sees_history_in_browser()
     test_unicode_renders_in_browser()
     test_resize_rebuilds_browser_terminal()
+    test_fullscreen_mode_scales_and_restores()

--- a/public/stylesheet/room.css
+++ b/public/stylesheet/room.css
@@ -40,6 +40,7 @@ header {
 /* Terminals wider than the page scroll horizontally instead of
    wrapping or clipping */
 #terminal {
+  position: relative;
   overflow-x: auto;
 }
 
@@ -50,6 +51,79 @@ header {
 
 .terminal > div {
   white-space: nowrap;
+}
+
+/* Fullscreen toggle: hidden until the terminal is hovered or the
+   button is focused */
+#fullscreen-toggle {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 2;
+  width: 32px;
+  height: 32px;
+  padding: 6px;
+  border: 0;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.45);
+  color: rgba(255, 255, 255, 0.85);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+#terminal:hover #fullscreen-toggle,
+#fullscreen-toggle:focus-visible {
+  opacity: 1;
+}
+
+/* While fullscreen the button must stay reachable: touch devices have
+   no hover (and the iOS fallback has no other way out), and the
+   viewport anchoring keeps it in place when an oversized terminal
+   scrolls */
+#terminal.fullscreen #fullscreen-toggle {
+  position: fixed;
+  opacity: 0.4;
+}
+
+#terminal.fullscreen #fullscreen-toggle:hover,
+#terminal.fullscreen #fullscreen-toggle:focus-visible {
+  opacity: 1;
+}
+
+#fullscreen-toggle:hover {
+  background: rgba(0, 0, 0, 0.7);
+}
+
+#fullscreen-toggle svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+#fullscreen-toggle .icon-compress {
+  display: none;
+}
+
+#terminal.fullscreen .icon-expand {
+  display: none;
+}
+
+#terminal.fullscreen .icon-compress {
+  display: block;
+}
+
+/* Fullscreen layout, driven by the class so it works both under the
+   native Fullscreen API and as a fill-the-page fallback */
+#terminal.fullscreen {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 100;
+  overflow: auto;
+  padding: 0;
 }
 
 .reverse-video {

--- a/templates/room.html
+++ b/templates/room.html
@@ -27,7 +27,16 @@
       </h1>
     </header>
     <div class="main">
-      <div id="terminal"></div>
+      <div id="terminal">
+        <button id="fullscreen-toggle" type="button" title="Fullscreen (f)" aria-label="Toggle fullscreen">
+          <svg class="icon-expand" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M8 3H5a2 2 0 0 0-2 2v3M16 3h3a2 2 0 0 1 2 2v3M8 21H5a2 2 0 0 1-2-2v-3M16 21h3a2 2 0 0 0 2-2v-3"/>
+          </svg>
+          <svg class="icon-compress" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M8 3v3a2 2 0 0 1-2 2H3M21 8h-3a2 2 0 0 1-2-2V3M3 16h3a2 2 0 0 1 2 2v3M16 21v-3a2 2 0 0 1 2-2h3"/>
+          </svg>
+        </button>
+      </div>
     </div>
     <footer>
       <p>shellshare is a free software (Apache License). Source code on <a href="https://github.com/vitorbaptista/shellshare">GitHub</a>.</p>
@@ -56,6 +65,7 @@
       var onlineCounterPlural = document.getElementById('online-counter-plural');
       var broadcastStatus = document.getElementById('broadcast-status');
       var terminalContainer = document.getElementById('terminal');
+      var fullscreenToggle = document.getElementById('fullscreen-toggle');
 
       if (typeof Terminal !== 'undefined') {
         Terminal.bindKeys = function() {
@@ -146,7 +156,136 @@
         }
 
         currentSize = size;
+        fitTerminal();
       }
+
+      // Fullscreen: the `fullscreen` class on #terminal drives all
+      // layout, so browsers without requestFullscreen on divs (iOS
+      // Safari) still get a fill-the-page mode. The native API only
+      // adds the OS chrome on top.
+      function isFullscreen() {
+        return terminalContainer.classList.contains('fullscreen');
+      }
+
+      function nativeFullscreenElement() {
+        return document.fullscreenElement ||
+               document.webkitFullscreenElement || null;
+      }
+
+      function enterFullscreen() {
+        terminalContainer.classList.add('fullscreen');
+        var rfs = terminalContainer.requestFullscreen ||
+                  terminalContainer.webkitRequestFullscreen;
+        if (rfs) {
+          // Older webkit doesn't return a promise
+          var result = rfs.call(terminalContainer);
+          if (result && result.catch) {
+            result.catch(function () {});
+          }
+        }
+        fitTerminal();
+      }
+
+      function exitFullscreen() {
+        if (nativeFullscreenElement()) {
+          var result = (document.exitFullscreen ||
+                        document.webkitExitFullscreen).call(document);
+          if (result && result.catch) {
+            result.catch(function () {});
+          }
+        }
+        terminalContainer.classList.remove('fullscreen');
+        fitTerminal();
+      }
+
+      function toggleFullscreen() {
+        if (isFullscreen()) {
+          exitFullscreen();
+        } else {
+          enterFullscreen();
+        }
+      }
+
+      // Scale the font so the broadcaster's cols×rows fill the screen.
+      // term.js sizing is purely font-size driven and .terminal is
+      // width: max-content, so its bounding box at the base size gives
+      // the exact ratio to scale by.
+      var MIN_FONT_PX = 7;
+      var fitScheduled = false;
+
+      function fitTerminal() {
+        if (!term) {
+          return;
+        }
+        var el = term.element;
+        el.style.fontSize = '';
+        if (!isFullscreen()) {
+          return;
+        }
+        // The stylesheet's base size, measured with the inline
+        // override cleared above
+        var baseFont = parseFloat(getComputedStyle(el).fontSize) || 14;
+        var rect = el.getBoundingClientRect();
+        var availWidth = terminalContainer.clientWidth;
+        var availHeight = terminalContainer.clientHeight;
+        if (!rect.width || !rect.height) {
+          return;
+        }
+        var scale = Math.min(availWidth / rect.width,
+                             availHeight / rect.height);
+        // Integer px keeps glyphs crisp
+        var px = Math.max(MIN_FONT_PX, Math.floor(baseFont * scale));
+        el.style.fontSize = px + 'px';
+        // Line-height rounding can push a pixel of overflow; nudge down
+        while (px > MIN_FONT_PX) {
+          rect = el.getBoundingClientRect();
+          if (rect.width <= availWidth && rect.height <= availHeight) {
+            break;
+          }
+          px -= 1;
+          el.style.fontSize = px + 'px';
+        }
+      }
+
+      function scheduleFit() {
+        if (fitScheduled) {
+          return;
+        }
+        fitScheduled = true;
+        requestAnimationFrame(function () {
+          fitScheduled = false;
+          fitTerminal();
+        });
+      }
+
+      // The native state is authoritative whenever it changes: this
+      // covers Esc and browser-UI exits, and re-syncs the class if a
+      // pending requestFullscreen resolves after a rapid toggle. The
+      // fallback path never fires this event, so its class handling
+      // is untouched.
+      function onFullscreenChange() {
+        terminalContainer.classList.toggle('fullscreen',
+                                           !!nativeFullscreenElement());
+        scheduleFit();
+      }
+
+      fullscreenToggle.addEventListener('click', toggleFullscreen);
+      window.addEventListener('resize', scheduleFit);
+      document.addEventListener('fullscreenchange', onFullscreenChange);
+      document.addEventListener('webkitfullscreenchange', onFullscreenChange);
+      document.addEventListener('keydown', function (e) {
+        if (e.defaultPrevented || e.repeat ||
+            e.ctrlKey || e.metaKey || e.altKey) {
+          return;
+        }
+        if (e.key === 'f' || e.key === 'F') {
+          toggleFullscreen();
+        } else if (e.key === 'Escape' && isFullscreen() &&
+                   !nativeFullscreenElement()) {
+          // Fallback mode only; native fullscreen handles its own Esc
+          exitFullscreen();
+        }
+      });
     })();
   </script>
 </body>


### PR DESCRIPTION
## What

Viewers can now watch a broadcast in fullscreen: hover the terminal and click the corner button, or press `f` (`Esc`/`f` exits).

- The terminal fills the screen anchored top-left, like a regular maximized terminal, with the theme background everywhere.
- The font auto-scales so the broadcaster's cols×rows fill the viewport (integer px for crisp glyphs), re-fitting on window resize, broadcaster resize, and theme changes. Terminals too wide even at the minimum size scroll instead of clipping.

## How

- A `fullscreen` class on `#terminal` drives all layout; the native Fullscreen API is layered on top. Browsers that can't fullscreen a div (iOS Safari) get a fill-the-page fallback from the same class, with the toggle button kept visible (no hover on touch) so there's always a way out.
- The native state is authoritative whenever its events fire, so Esc/browser-UI exits and rapid-toggle races can't desync the class.
- The fit algorithm measures the rendered terminal at the stylesheet's base size and scales proportionally — term.js sizing is purely font-size driven.
- The button is a sibling of term.js's `.terminal` inside `#terminal`, so it survives terminal rebuilds and the existing e2e DOM contract is untouched.

## Testing

- New e2e test `test_fullscreen_mode_scales_and_restores`: enter via `f`, DOM contract preserved, font scaled up, exit restores the default layout.
- Full suite: 205 passed, 3 skipped. `make lint` clean.
- Two subagent review rounds; all findings fixed (touch exit affordance, toggle race, base font duplication).

Fixes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)