### PR TITLE
fix: remove horizontal page scroll caused by footer margin

### DIFF
--- a/public/stylesheet/base.css
+++ b/public/stylesheet/base.css
@@ -49,7 +49,7 @@ footer {
   margin-left: 0;
   color: #333333;
   width: 100%;
-  margin: 2em;
+  margin: 2em 0;
   text-transform: uppercase;
   text-align: center;
   font-size: 0.7em;


### PR DESCRIPTION
## Summary
- The room page (and home page) showed a horizontal scrollbar with an empty white strip on the right.
- Cause: the absolutely-positioned `footer` in `public/stylesheet/base.css` had `width: 100%` plus `margin: 2em`, pushing its right edge ~22px past the page edge.
- Fix: `margin: 2em` → `margin: 2em 0`, keeping vertical spacing and dropping the horizontal margin.

## Verification
Measured with Playwright on `/r/testroom` at a 1100px viewport: `document.documentElement.scrollWidth` was 1122 before the fix and 1100 after (equal to `clientWidth`, i.e. no horizontal scroll).

🤖 Generated with [Claude Code](https://claude.com/claude-code)