### PR TITLE
Add optional, privacy-preserving PostHog analytics to the server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,9 +148,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -169,6 +169,12 @@ checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -254,6 +260,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,6 +329,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -305,10 +338,21 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "block2",
  "libc",
  "objc2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -480,6 +524,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,6 +602,22 @@ dependencies = [
  "pin-utils",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -557,14 +626,125 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -574,6 +754,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -589,6 +785,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +855,12 @@ name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -726,7 +988,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -739,7 +1001,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -780,6 +1042,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "parking_lot"
@@ -841,6 +1109,15 @@ dependencies = [
  "shell-words",
  "winapi",
  "winreg",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -941,7 +1218,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -960,6 +1237,42 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "reqwest"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "ring"
@@ -1012,16 +1325,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.23.36"
+name = "rustc_version"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1032,6 +1367,33 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -1066,6 +1428,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,6 +1447,35 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1241,15 +1641,19 @@ dependencies = [
  "clap",
  "ctrlc",
  "hex",
+ "hmac",
  "libc",
  "mac_address",
  "mime_guess",
  "percent-encoding",
  "portable-pty",
  "rand 0.8.6",
+ "reqwest",
  "rust-embed",
+ "rustls",
  "serde",
  "serde_json",
+ "sha2",
  "signal-hook",
  "socketioxide",
  "term_size",
@@ -1286,6 +1690,22 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -1361,6 +1781,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "state"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,6 +1823,20 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "term_size"
@@ -1467,6 +1907,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1492,6 +1942,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -1553,7 +2013,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -1562,12 +2022,14 @@ dependencies = [
  "http-body-util",
  "http-range-header",
  "httpdate",
+ "iri-string",
  "mime",
  "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "tokio",
  "tokio-util",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1648,6 +2110,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "tungstenite"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1726,10 +2194,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1760,6 +2246,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1772,6 +2267,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2067,6 +2636,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2087,10 +2685,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,10 @@ signal-hook = "0.4.3"
 hex = "0.4.3"
 tungstenite = { version = "0.29.0", features = ["rustls-tls-webpki-roots"] }
 bytes = "1.11.1"
+hmac = "0.12.1"
+sha2 = "0.10.9"
+reqwest = { version = "=0.13.3", default-features = false, features = ["rustls-no-provider", "json"] }
+rustls = { version = "0.23.40", default-features = false, features = ["ring", "std"] }
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -67,6 +67,31 @@ dokku builder-dockerfile:set shellshare dockerfile-path Dockerfile.production
 make deploy
 ```
 
+## Analytics (optional, off by default)
+
+The server can send anonymous usage events (rooms created, broadcast
+durations, viewer counts) to [PostHog](https://posthog.com). Nothing is
+collected unless you opt in by setting both variables:
+
+```bash
+SHELLSHARE_POSTHOG_KEY=phc_yourprojectkey \
+SHELLSHARE_POSTHOG_SALT=some-long-random-secret \
+shellshare server
+```
+
+(Set `SHELLSHARE_POSTHOG_HOST` for self-hosted PostHog. The equivalent
+`--posthog-*` flags also exist, but prefer the environment variables:
+the salt is a secret, and command-line arguments are visible to other
+local users.)
+
+No personal data is sent: no IP addresses, no room names, no passwords.
+Broadcasters are identified only by `HMAC-SHA256(salt, password)` and
+rooms by `HMAC-SHA256(salt, room_name)`, which lets the operator count
+returning users without being able to identify anyone. Keep the salt
+stable across restarts and servers so returning users stay recognizable;
+rotating it resets all identities. Events are fire-and-forget and never
+block or slow down broadcasting.
+
 ## Releasing
 
 ```bash

--- a/e2e/test_analytics.py
+++ b/e2e/test_analytics.py
@@ -1,0 +1,275 @@
+"""
+E2E tests for the optional PostHog analytics.
+
+These spawn dedicated servers pointing --posthog-host at a local mock
+that records every capture request. Delivery is fire-and-forget on the
+server side, so assertions poll the mock instead of expecting events
+immediately after the triggering action.
+"""
+
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from conftest import (
+    SocketListener,
+    broadcast_message,
+    poll_until,
+    random_id,
+    ws_connect_room,
+)
+
+POSTHOG_KEY = "phc_test_key"
+POSTHOG_SALT = "e2e-test-salt"
+
+
+class MockPostHog:
+    """A local stand-in for PostHog's capture endpoint."""
+
+    def __init__(self):
+        self.events = []
+        self._lock = threading.Lock()
+
+        mock = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", 0))
+                body = json.loads(self.rfile.read(length))
+                with mock._lock:
+                    mock.events.append(body)
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b'{"status": 1}')
+
+            def log_message(self, *args):
+                pass  # keep pytest output clean
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._thread = threading.Thread(
+            target=self._server.serve_forever, daemon=True
+        )
+        self._thread.start()
+
+    @property
+    def url(self):
+        return f"http://127.0.0.1:{self._server.server_address[1]}"
+
+    def events_named(self, name):
+        with self._lock:
+            return [e for e in self.events if e.get("event") == name]
+
+    def shutdown(self):
+        self._server.shutdown()
+        self._server.server_close()
+
+
+@pytest.fixture
+def mock_posthog():
+    mock = MockPostHog()
+    yield mock
+    mock.shutdown()
+
+
+def analytics_server(dedicated_server, mock_posthog, *extra_args):
+    return dedicated_server(
+        "--posthog-key", POSTHOG_KEY,
+        "--posthog-host", mock_posthog.url,
+        "--posthog-salt", POSTHOG_SALT,
+        *extra_args,
+    )
+
+
+def test_full_lifecycle_emits_the_three_events(dedicated_server, mock_posthog):
+    server = analytics_server(dedicated_server, mock_posthog)
+    room = random_id()
+    password = "secret-password"
+
+    # Broadcast: claim the room, send output, have a viewer join, exit
+    # cleanly (the delete control message, as the CLI sends on exit)
+    ws = ws_connect_room(server.url, room, password)
+    try:
+        ws.send_binary(b"hello viewers")
+        ws.recv()  # ack
+
+        listener = SocketListener(room, server_url=server.url)
+        listener.connect()
+        try:
+            assert poll_until(
+                lambda: mock_posthog.events_named("viewer_joined"), timeout=10
+            ), "viewer_joined never reached the mock"
+        finally:
+            listener.disconnect()
+
+        ws.send(json.dumps({"delete": True}))
+    finally:
+        ws.close()
+
+    assert poll_until(
+        lambda: mock_posthog.events_named("room_created")
+        and mock_posthog.events_named("broadcast_ended"),
+        timeout=10,
+    ), "room_created/broadcast_ended never reached the mock"
+
+    created = mock_posthog.events_named("room_created")[0]
+    ended = mock_posthog.events_named("broadcast_ended")[0]
+    viewed = mock_posthog.events_named("viewer_joined")[0]
+
+    # The broadcaster identity is stable across events and prefixed,
+    # the room identity lives in a different id space
+    assert created["distinct_id"].startswith("bc:")
+    assert ended["distinct_id"] == created["distinct_id"]
+    assert viewed["distinct_id"].startswith("room:")
+
+    assert created["api_key"] == POSTHOG_KEY
+    assert isinstance(ended["properties"]["duration_seconds"], (int, float))
+    assert viewed["properties"]["user_count"] >= 1
+    assert viewed["properties"]["broadcasting"] is True
+
+    for event in (created, ended, viewed):
+        assert event["properties"]["$process_person_profile"] is False
+        assert event["properties"]["$geoip_disable"] is True
+        # No PII: neither the room name nor the password may appear
+        # anywhere in any payload
+        payload = json.dumps(event)
+        assert room not in payload
+        assert password not in payload
+
+
+def test_viewer_rejoin_and_dead_rooms_are_not_counted(dedicated_server, mock_posthog):
+    server = analytics_server(dedicated_server, mock_posthog)
+    room = random_id()
+
+    # A join to a room that doesn't exist (dead link) is not an audience
+    listener = SocketListener(room, server_url=server.url)
+    listener.connect()
+    listener.disconnect()
+
+    ws = ws_connect_room(server.url, room, "pw")
+    try:
+        listener = SocketListener(room, server_url=server.url)
+        listener.connect()
+        try:
+            assert poll_until(
+                lambda: mock_posthog.events_named("viewer_joined"), timeout=10
+            )
+            # Clients re-emit join until confirmed; a re-emitted join is
+            # not a new viewer. Wait for its usersCount confirmation so
+            # the server has definitely processed it before asserting.
+            counts_before = len(listener._user_counts)
+            listener._sio.emit("join", f"/r/{room}")
+            assert poll_until(
+                lambda: len(listener._user_counts) > counts_before, timeout=10
+            ), "re-emitted join was never confirmed"
+            # Neither the dead-link join nor the re-join may have produced
+            # an event: exactly one for the single live join
+            time.sleep(1)
+            assert len(mock_posthog.events_named("viewer_joined")) == 1
+        finally:
+            listener.disconnect()
+    finally:
+        ws.close()
+
+
+def test_abrupt_disconnect_emits_one_broadcast_ended(dedicated_server, mock_posthog):
+    server = analytics_server(dedicated_server, mock_posthog)
+    room = random_id()
+
+    ws = ws_connect_room(server.url, room, "pw")
+    ws.send_binary(b"output")
+    ws.recv()  # ack
+    # Drop the connection without the delete control message, like a
+    # crashed client or a dead network
+    ws.close()
+
+    assert poll_until(
+        lambda: mock_posthog.events_named("broadcast_ended"), timeout=10
+    ), "broadcast_ended never reached the mock"
+    time.sleep(1)
+    assert len(mock_posthog.events_named("broadcast_ended")) == 1
+
+    # The room outlives its broadcaster until TTL eviction; a viewer of
+    # that replay still counts, flagged as not broadcasting
+    listener = SocketListener(room, server_url=server.url)
+    listener.connect()
+    try:
+        assert poll_until(
+            lambda: mock_posthog.events_named("viewer_joined"), timeout=10
+        ), "viewer_joined never reached the mock"
+    finally:
+        listener.disconnect()
+    assert mock_posthog.events_named("viewer_joined")[0]["properties"][
+        "broadcasting"
+    ] is False
+
+
+def test_clean_exit_emits_exactly_one_broadcast_ended(dedicated_server, mock_posthog):
+    server = analytics_server(dedicated_server, mock_posthog)
+    room = random_id()
+
+    # Delete (the CLI's exit path) followed by the close must not report
+    # the broadcast twice
+    ws = ws_connect_room(server.url, room, "pw")
+    try:
+        ws.send(json.dumps({"delete": True}))
+    finally:
+        ws.close()
+
+    assert poll_until(
+        lambda: mock_posthog.events_named("broadcast_ended"), timeout=10
+    )
+    time.sleep(1)
+    assert len(mock_posthog.events_named("broadcast_ended")) == 1
+
+
+def test_no_salt_disables_analytics(dedicated_server, mock_posthog):
+    server = dedicated_server(
+        "--posthog-key", POSTHOG_KEY,
+        "--posthog-host", mock_posthog.url,
+    )
+    room = random_id()
+
+    assert broadcast_message(server.url, room, "pw", text="hi") == 200
+
+    # Fire-and-forget delivery means absence can only be asserted after
+    # a settle window
+    time.sleep(1.5)
+    assert mock_posthog.events == []
+
+
+def test_serve_mode_sends_no_analytics(mock_posthog):
+    # `shellshare serve` embeds the server with analytics hardcoded off;
+    # the env vars that configure `shellshare server` must not leak in
+    import os
+    import subprocess
+
+    from conftest import CLI_COMMAND, _free_port, wait_for_server
+
+    port = _free_port()
+    env = dict(
+        os.environ,
+        SHELLSHARE_POSTHOG_KEY=POSTHOG_KEY,
+        SHELLSHARE_POSTHOG_HOST=mock_posthog.url,
+        SHELLSHARE_POSTHOG_SALT=POSTHOG_SALT,
+    )
+    proc = subprocess.Popen(
+        CLI_COMMAND + ["--stdin", "serve", "--host", "127.0.0.1", "--port", str(port)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=env,
+    )
+    try:
+        wait_for_server(f"http://127.0.0.1:{port}")
+        proc.stdin.write(b"hello\n")
+        proc.stdin.flush()
+        time.sleep(1.5)
+        assert mock_posthog.events == []
+    finally:
+        proc.stdin.close()
+        proc.terminate()
+        proc.wait(timeout=10)

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,21 @@ enum Commands {
         /// Room TTL in seconds - rooms inactive for this long are removed (default: 21600 = 6 hours)
         #[arg(long, default_value_t = DEFAULT_ROOM_TTL_SECS)]
         room_ttl: u64,
+
+        /// `PostHog` project API key. Usage analytics are sent only when
+        /// this AND --posthog-salt are set; otherwise nothing is collected
+        #[arg(long, env = "SHELLSHARE_POSTHOG_KEY")]
+        posthog_key: Option<String>,
+
+        /// `PostHog` ingestion host to send analytics events to
+        #[arg(long, env = "SHELLSHARE_POSTHOG_HOST", default_value = server::DEFAULT_POSTHOG_HOST)]
+        posthog_host: String,
+
+        /// Secret salt for pseudonymizing analytics identifiers. Keep it
+        /// stable across restarts and servers so returning users stay
+        /// recognizable; rotating it resets all identities
+        #[arg(long, env = "SHELLSHARE_POSTHOG_SALT")]
+        posthog_salt: Option<String>,
     },
     /// Share your terminal through a local server (no external server needed)
     Serve {
@@ -131,10 +146,13 @@ fn start_local_server(host: &str, port: u16) -> Result<std::net::SocketAddr, Str
                     return;
                 }
             }
+            // The embedded server never sends analytics: it serves the
+            // machine's own broadcast, not an operator's deployment
             if let Err(e) = server::serve_on(
                 listeners,
                 DEFAULT_CLEANUP_INTERVAL_SECS,
                 DEFAULT_ROOM_TTL_SECS,
+                None,
             )
             .await
             {
@@ -151,6 +169,35 @@ fn start_local_server(host: &str, port: u16) -> Result<std::net::SocketAddr, Str
         .map_err(|e| format!("could not start local server on {host}:{port}: {e}"))
 }
 
+/// Build the analytics config from the server's PostHog flags.
+///
+/// Both the key and the salt are required; refusing a half-configured
+/// setup beats silently degrading it (a random fallback salt would
+/// reset every identity on restart and corrupt the recurring-user
+/// metric invisibly), so each half-configured case warns and disables.
+fn analytics_config(
+    key: Option<String>,
+    host: String,
+    salt: Option<String>,
+) -> Option<server::AnalyticsConfig> {
+    match (key, salt) {
+        (Some(api_key), Some(salt)) => Some(server::AnalyticsConfig {
+            api_key,
+            host,
+            salt,
+        }),
+        (Some(_), None) => {
+            tracing::warn!("Analytics disabled: --posthog-key is set but --posthog-salt is not");
+            None
+        }
+        (None, Some(_)) => {
+            tracing::warn!("Analytics disabled: --posthog-salt is set but --posthog-key is not");
+            None
+        }
+        (None, None) => None,
+    }
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
@@ -160,6 +207,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             port,
             cleanup_interval,
             room_ttl,
+            posthog_key,
+            posthog_host,
+            posthog_salt,
         }) => {
             // Initialize logging for server
             let subscriber = FmtSubscriber::builder()
@@ -167,9 +217,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .finish();
             tracing::subscriber::set_global_default(subscriber)?;
 
+            let analytics_config = analytics_config(posthog_key, posthog_host, posthog_salt);
+
             // Create runtime only for server mode
             let runtime = tokio::runtime::Runtime::new()?;
-            runtime.block_on(server::run(&host, port, cleanup_interval, room_ttl))?;
+            runtime.block_on(server::run(
+                &host,
+                port,
+                cleanup_interval,
+                room_ttl,
+                analytics_config,
+            ))?;
         }
         Some(Commands::Serve { host, port }) => {
             // No tracing subscriber on purpose: the embedded server's

--- a/src/server/analytics.rs
+++ b/src/server/analytics.rs
@@ -1,0 +1,226 @@
+//! Optional, privacy-preserving usage analytics (`PostHog`).
+//!
+//! Disabled unless the operator configures an API key AND a salt; with
+//! either missing this module is a no-op and nothing ever leaves the
+//! server. Design constraints, in order:
+//!
+//! - **Never slow the broadcast path**: events go through a bounded
+//!   channel with `try_send` (full channel = event dropped) into one
+//!   background task that does the HTTP work. Losing events is fine;
+//!   blocking ingest is not.
+//! - **No PII**: no IP addresses (`PostHog` only ever sees this server's
+//!   own requests, sent with `$geoip_disable`), no room names, no
+//!   passwords. The only identifier is `HMAC-SHA256(salt, password)`:
+//!   the default client password is MAC-derived, so the HMAC is stable
+//!   per machine (recurring-user detection) while the secret salt keeps
+//!   the small MAC space safe from enumeration and keeps custom
+//!   passwords uncrackable from the analytics data.
+//! - **Stateless server**: the salt is operator-supplied, not generated,
+//!   so identities survive restarts and server moves (reuse the salt).
+//!
+//! The counts are best-effort, not bookkeeping: a few edge cases skew
+//! them slightly (a handshake that claims a room but never upgrades
+//! emits `room_created` with no matching `broadcast_ended`; a room
+//! resurrected by a ping after a delete race or a mid-broadcast TTL
+//! eviction emits neither), and a broadcast interrupted by reconnects
+//! reports one `broadcast_ended` per live segment. Good enough for
+//! "how much is shellshare used".
+
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tracing::{debug, info, warn};
+
+/// Default `PostHog` ingestion endpoint (US cloud).
+pub const DEFAULT_POSTHOG_HOST: &str = "https://us.i.posthog.com";
+
+/// Events waiting for the sender task. Volume is tiny (a handful per
+/// broadcast/viewer), so a small buffer only ever fills if `PostHog` is
+/// unreachable and events pile up behind timeouts - exactly when
+/// dropping them is the right call.
+const QUEUE_CAPACITY: usize = 256;
+
+/// Per-request timeout: `PostHog` being slow must never pin the sender
+/// task (and thus the queue) for long.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Operator-provided analytics settings.
+pub struct Config {
+    pub api_key: String,
+    pub host: String,
+    pub salt: String,
+}
+
+/// One analytics event, queued for delivery.
+struct Event {
+    name: &'static str,
+    distinct_id: String,
+    properties: serde_json::Value,
+}
+
+/// Handle for emitting analytics events. Cheap to clone; a disabled
+/// handle (no config) drops every event without any work.
+#[derive(Clone, Default)]
+pub struct Analytics {
+    inner: Option<Inner>,
+}
+
+#[derive(Clone)]
+struct Inner {
+    tx: mpsc::Sender<Event>,
+    salt: String,
+}
+
+impl Analytics {
+    /// Build the handle and spawn the sender task. `None` config (or a
+    /// config that can't produce an HTTP client) yields a no-op handle.
+    ///
+    /// Must be called from within a Tokio runtime.
+    pub fn new(config: Option<Config>) -> Self {
+        let Some(config) = config else {
+            return Self { inner: None };
+        };
+
+        // reqwest is built without a default TLS provider (the in-tree
+        // provider is ring, shared with the client's WebSocket TLS);
+        // install it process-wide, tolerating an already-installed one
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let client = match reqwest::Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .use_rustls_tls()
+            .build()
+        {
+            Ok(client) => client,
+            Err(e) => {
+                warn!("Analytics disabled: could not build HTTP client: {e}");
+                return Self { inner: None };
+            }
+        };
+
+        info!("Analytics enabled, sending to {}", config.host);
+        let (tx, rx) = mpsc::channel(QUEUE_CAPACITY);
+        tokio::spawn(sender_task(client, config.api_key, config.host, rx));
+
+        Self {
+            inner: Some(Inner {
+                tx,
+                salt: config.salt,
+            }),
+        }
+    }
+
+    /// A room was claimed by a broadcaster.
+    pub fn room_created(&self, password: &str) {
+        if let Some(inner) = &self.inner {
+            inner.send(Event {
+                name: "room_created",
+                distinct_id: inner.broadcaster_id(password),
+                properties: serde_json::json!({}),
+            });
+        }
+    }
+
+    /// A live segment ended: the room's last ingest connection detached
+    /// (or the room was deleted under it). `duration` spans the segment,
+    /// so one broadcast interrupted by reconnects yields several events
+    /// whose durations sum to the time actually spent live.
+    pub fn broadcast_ended(&self, password: &str, duration: Duration) {
+        if let Some(inner) = &self.inner {
+            inner.send(Event {
+                name: "broadcast_ended",
+                distinct_id: inner.broadcaster_id(password),
+                properties: serde_json::json!({
+                    // Fractional: short segments would otherwise all
+                    // truncate to 0 and undercount reconnect-heavy runs
+                    "duration_seconds": duration.as_secs_f64(),
+                }),
+            });
+        }
+    }
+
+    /// A viewer joined an existing room - live (`broadcasting`) or a
+    /// replay of one whose broadcaster dropped but wasn't evicted yet.
+    /// Viewers send no credentials, so the identity is the room's, not
+    /// the viewer's: this measures rooms that got an audience and how
+    /// big it was, not unique viewers.
+    pub fn viewer_joined(&self, room_name: &str, user_count: usize, broadcasting: bool) {
+        if let Some(inner) = &self.inner {
+            inner.send(Event {
+                name: "viewer_joined",
+                distinct_id: inner.room_id(room_name),
+                properties: serde_json::json!({
+                    "user_count": user_count,
+                    "broadcasting": broadcasting,
+                }),
+            });
+        }
+    }
+}
+
+impl Inner {
+    /// Queue an event; a full queue or closed channel drops it.
+    fn send(&self, event: Event) {
+        if let Err(e) = self.tx.try_send(event) {
+            debug!("Analytics event dropped: {e}");
+        }
+    }
+
+    /// Stable pseudonymous broadcaster identity. The `bc:` prefix keeps
+    /// this id space disjoint from room-derived ids.
+    fn broadcaster_id(&self, password: &str) -> String {
+        format!("bc:{}", hmac_hex(&self.salt, password))
+    }
+
+    /// Stable pseudonymous room identity for viewer events.
+    fn room_id(&self, room_name: &str) -> String {
+        format!("room:{}", hmac_hex(&self.salt, room_name))
+    }
+}
+
+/// `HMAC-SHA256(salt, value)` as lowercase hex.
+fn hmac_hex(salt: &str, value: &str) -> String {
+    // HMAC accepts keys of any length; new_from_slice cannot fail
+    let mut mac = Hmac::<Sha256>::new_from_slice(salt.as_bytes())
+        .expect("HMAC accepts any key length");
+    mac.update(value.as_bytes());
+    hex::encode(mac.finalize().into_bytes())
+}
+
+/// The single background task that delivers queued events to `PostHog`.
+/// Failures are logged at debug and the event is dropped - analytics
+/// must never demand a retry budget from the server.
+async fn sender_task(
+    client: reqwest::Client,
+    api_key: String,
+    host: String,
+    mut rx: mpsc::Receiver<Event>,
+) {
+    let url = format!("{}/i/v0/e/", host.trim_end_matches('/'));
+    while let Some(event) = rx.recv().await {
+        let mut properties = event.properties;
+        // Anonymous events: no person profiles (distinct_id-based
+        // unique counts still work), and no GeoIP enrichment - PostHog
+        // would otherwise tag events with this server's location
+        properties["$process_person_profile"] = serde_json::Value::Bool(false);
+        properties["$geoip_disable"] = serde_json::Value::Bool(true);
+        let body = serde_json::json!({
+            "api_key": api_key,
+            "event": event.name,
+            "distinct_id": event.distinct_id,
+            "properties": properties,
+        });
+        match client.post(&url).json(&body).send().await {
+            Ok(response) if response.status().is_success() => {}
+            Ok(response) => {
+                debug!(
+                    "Analytics event {} rejected: {}",
+                    event.name,
+                    response.status()
+                );
+            }
+            Err(e) => debug!("Analytics event {} failed: {e}", event.name),
+        }
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2,9 +2,12 @@
 //!
 //! This module contains the server implementation using axum + socketioxide.
 
+mod analytics;
 mod binaries;
 mod pages;
 mod rooms;
+
+pub use analytics::{Config as AnalyticsConfig, DEFAULT_POSTHOG_HOST};
 
 use axum::{
     body::Body,
@@ -63,6 +66,8 @@ struct AppState {
     socket_rooms: Arc<RwLock<HashMap<String, Vec<String>>>>,
     /// Cleanup configuration for abandoned rooms
     cleanup_config: CleanupConfig,
+    /// Optional usage analytics; a no-op unless the operator opted in
+    analytics: analytics::Analytics,
 }
 
 /// What `POST /r/:room` answers since the WebSocket transport replaced
@@ -79,9 +84,10 @@ pub async fn run(
     port: u16,
     cleanup_interval_secs: u64,
     room_ttl_secs: u64,
+    analytics_config: Option<AnalyticsConfig>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let listeners = bind(host, port).await?;
-    serve_on(listeners, cleanup_interval_secs, room_ttl_secs).await
+    serve_on(listeners, cleanup_interval_secs, room_ttl_secs, analytics_config).await
 }
 
 /// Bind the server's TCP listeners.
@@ -129,6 +135,7 @@ pub async fn serve_on(
     listeners: Vec<tokio::net::TcpListener>,
     cleanup_interval_secs: u64,
     room_ttl_secs: u64,
+    analytics_config: Option<AnalyticsConfig>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     for listener in &listeners {
         info!("Starting shellshare server on {}", listener.local_addr()?);
@@ -144,6 +151,7 @@ pub async fn serve_on(
             interval: Duration::from_secs(cleanup_interval_secs),
             inactive_ttl: Duration::from_secs(room_ttl_secs),
         },
+        analytics: analytics::Analytics::new(analytics_config),
         ..Default::default()
     };
 
@@ -223,7 +231,10 @@ fn setup_socket_handlers(io: &SocketIo) {
                 // emitting usersCount more than once per room.
                 let mut socket_rooms = state.socket_rooms.write().await;
                 let tracked = socket_rooms.entry(socket.id.to_string()).or_default();
-                if !tracked.contains(&room_name) {
+                // Re-emitted joins are not new viewers; remember which
+                // this was so analytics counts each socket once per room
+                let newly_joined = !tracked.contains(&room_name);
+                if newly_joined {
                     tracked.push(room_name.clone());
                 }
                 // Release before the room snapshot below takes its own lock
@@ -231,6 +242,7 @@ fn setup_socket_handlers(io: &SocketIo) {
 
                 // Catch the viewer up if the room is live
                 let snapshot = state.rooms.snapshot(&room_id).await;
+                let room_exists = snapshot.is_some();
                 let broadcasting = snapshot.as_ref().is_some_and(|s| s.broadcasting);
                 if let Some(snapshot) = snapshot {
                     // Send size FIRST - terminal must be sized before receiving content
@@ -268,6 +280,15 @@ fn setup_socket_handlers(io: &SocketIo) {
 
                 // Also broadcast to notify other clients in the room
                 let _ = socket.within(room_name).emit("usersCount", &user_count);
+
+                // Joins to nonexistent rooms (dead links) are not an
+                // audience and would only inflate the numbers; replay
+                // viewers count, flagged by `broadcasting`
+                if newly_joined && room_exists {
+                    state
+                        .analytics
+                        .viewer_joined(room_id.as_str(), user_count, broadcasting);
+                }
             },
         );
 
@@ -330,7 +351,7 @@ async fn ingest(
     size: Option<&serde_json::Value>,
     message: Option<&Bytes>,
 ) -> Result<(), rooms::Unauthorized> {
-    state.rooms.append(room_id, secret, size, message).await?;
+    let _ = state.rooms.append(room_id, secret, size, message).await?;
 
     if let Some(io) = state.io.get() {
         let room_name = room_id.as_str().to_string();
@@ -367,13 +388,12 @@ async fn ws_ingest_handler(
     let room_id = RoomId::parse(&room_path);
     let secret = auth_secret(&headers).to_string();
 
-    if state
-        .rooms
-        .append(&room_id, &secret, None, None)
-        .await
-        .is_err()
-    {
-        return plain_response(StatusCode::UNAUTHORIZED, "Unauthorized");
+    match state.rooms.append(&room_id, &secret, None, None).await {
+        Ok(rooms::Appended::Claimed) => state.analytics.room_created(&secret),
+        Ok(rooms::Appended::Verified) => {}
+        Err(rooms::Unauthorized) => {
+            return plain_response(StatusCode::UNAUTHORIZED, "Unauthorized");
+        }
     }
 
     info!("WS ingest connected for room {:?}", room_id);
@@ -409,7 +429,7 @@ async fn ws_ingest_loop(mut socket: WebSocket, state: AppState, room_id: RoomId,
     // room as live while at least one ingest connection is attached.
     // A count of 0 means the room vanished between handshake and
     // upgrade - the loop below then ends on its first failed append.
-    if state.rooms.broadcaster_connected(&room_id).await > 0 {
+    if state.rooms.broadcaster_connected(&room_id, &secret).await > 0 {
         emit_broadcasting(&state, &room_id, true);
     }
 
@@ -432,7 +452,12 @@ async fn ws_ingest_loop(mut socket: WebSocket, state: AppState, room_id: RoomId,
                     continue;
                 };
                 if body.get("delete").and_then(serde_json::Value::as_bool) == Some(true) {
-                    let _ = state.rooms.delete(&room_id, &secret).await;
+                    // The clean-exit path: deleting removes the room, so
+                    // this is the last chance to know the live segment's
+                    // length (the loop's own detach below finds nothing)
+                    if let Ok(Some(duration)) = state.rooms.delete(&room_id, &secret).await {
+                        state.analytics.broadcast_ended(&secret, duration);
+                    }
                     break;
                 }
                 let size = body
@@ -446,7 +471,8 @@ async fn ws_ingest_loop(mut socket: WebSocket, state: AppState, room_id: RoomId,
             // axum answers pings itself; a ping still refreshes the room
             // so an idle-but-connected broadcast isn't evicted
             WsMessage::Ping(_) | WsMessage::Pong(_) => {
-                (state.rooms.append(&room_id, &secret, None, None).await, false)
+                let result = state.rooms.append(&room_id, &secret, None, None).await;
+                (result.map(|_| ()), false)
             }
             WsMessage::Close(_) => break,
         };
@@ -463,8 +489,14 @@ async fn ws_ingest_loop(mut socket: WebSocket, state: AppState, room_id: RoomId,
     }
     info!("WS ingest disconnected for room {:?}", room_id);
 
-    if state.rooms.broadcaster_disconnected(&room_id).await == 0 {
+    let (remaining, duration) = state.rooms.broadcaster_disconnected(&room_id, &secret).await;
+    if remaining == 0 {
         emit_broadcasting(&state, &room_id, false);
+    }
+    // `duration` is Some only when this detach ended a still-live
+    // room's segment; the delete paths already reported theirs
+    if let Some(duration) = duration {
+        state.analytics.broadcast_ended(&secret, duration);
     }
 }
 
@@ -505,8 +537,14 @@ async fn delete_room_handler(
         !secret.is_empty()
     );
 
-    if state.rooms.delete(&room_id, secret).await.is_err() {
-        return plain_response(StatusCode::UNAUTHORIZED, "Unauthorized");
+    match state.rooms.delete(&room_id, secret).await {
+        // Deleting out from under a live broadcaster ends its segment
+        // here; its loop then finds the room gone and reports nothing
+        Ok(Some(duration)) => state.analytics.broadcast_ended(secret, duration),
+        Ok(None) => {}
+        Err(rooms::Unauthorized) => {
+            return plain_response(StatusCode::UNAUTHORIZED, "Unauthorized");
+        }
     }
 
     plain_response(StatusCode::ACCEPTED, "Accepted")

--- a/src/server/rooms.rs
+++ b/src/server/rooms.rs
@@ -60,6 +60,15 @@ impl std::fmt::Display for RoomId {
 #[derive(Debug)]
 pub struct Unauthorized;
 
+/// What an authorized [`Rooms::append`] did to the room.
+#[derive(Debug)]
+pub enum Appended {
+    /// The room did not exist; this call claimed it.
+    Claimed,
+    /// The room existed and the password matched.
+    Verified,
+}
+
 /// Everything a late joiner needs to catch up with a live room.
 pub struct RoomSnapshot {
     /// Current terminal size; must be applied before the history
@@ -78,6 +87,12 @@ struct Room {
     messages: MessageHistory,
     /// Terminal size, forwarded verbatim to viewers
     size: Option<serde_json::Value>,
+    /// When the current live segment started (broadcaster count went
+    /// 0 -> 1). Broadcast durations are measured per segment, so a
+    /// reconnect yields two events whose durations sum to the real
+    /// broadcast time instead of overlapping spans measured from the
+    /// claim. `None` while no broadcaster is attached.
+    live_since: Option<Instant>,
     /// Last activity (broadcast or viewer join), drives eviction
     last_activity: Instant,
     /// Ingest connections currently attached. More than one is possible
@@ -92,6 +107,7 @@ impl Room {
             password: password.to_string(),
             messages: MessageHistory::new(MAX_HISTORY_MESSAGES),
             size: None,
+            live_since: None,
             last_activity: Instant::now(),
             broadcasters: 0,
         }
@@ -113,6 +129,9 @@ impl Rooms {
     /// by the caller (see `protocol::size_has_dimensions`); `message` is
     /// raw terminal bytes (`Bytes` clones share the buffer, so the caller
     /// keeps emitting from the same payload without copying).
+    ///
+    /// Reports whether this call [`Appended::Claimed`] the room, so the
+    /// caller can observe room creation without a separate lookup.
     #[allow(clippy::significant_drop_tightening)] // the lock spanning verify+mutate IS the invariant
     pub async fn append(
         &self,
@@ -120,11 +139,13 @@ impl Rooms {
         secret: &str,
         size: Option<&serde_json::Value>,
         message: Option<&Bytes>,
-    ) -> Result<(), Unauthorized> {
+    ) -> Result<Appended, Unauthorized> {
         let mut rooms = self.inner.write().await;
-        let entry = rooms
-            .entry(room.clone())
-            .or_insert_with(|| Room::new(secret));
+        let mut appended = Appended::Verified;
+        let entry = rooms.entry(room.clone()).or_insert_with(|| {
+            appended = Appended::Claimed;
+            Room::new(secret)
+        });
 
         if entry.password != secret {
             return Err(Unauthorized);
@@ -140,7 +161,7 @@ impl Rooms {
             entry.messages.push(message.clone());
         }
 
-        Ok(())
+        Ok(appended)
     }
 
     /// Catch-up data for a joining viewer; refreshes the room's activity.
@@ -159,40 +180,69 @@ impl Rooms {
 
     /// Record that a broadcaster's ingest connection attached to the
     /// room. Returns the new connection count (0 when the room vanished
-    /// between the handshake and the upgrade).
-    pub async fn broadcaster_connected(&self, room: &RoomId) -> usize {
+    /// between the handshake and the upgrade, or was re-claimed by
+    /// another password in that window - this connection must not touch
+    /// the new owner's bookkeeping).
+    pub async fn broadcaster_connected(&self, room: &RoomId, secret: &str) -> usize {
         let mut rooms = self.inner.write().await;
         rooms.get_mut(room).map_or(0, |entry| {
+            if entry.password != secret {
+                return 0;
+            }
+            if entry.broadcasters == 0 {
+                entry.live_since = Some(Instant::now());
+            }
             entry.broadcasters += 1;
             entry.broadcasters
         })
     }
 
     /// Record that a broadcaster's ingest connection detached. Returns
-    /// the remaining count; 0 also covers a room already deleted (the
-    /// `{"delete": true}` path removes the room before the loop ends).
-    pub async fn broadcaster_disconnected(&self, room: &RoomId) -> usize {
+    /// the remaining count - 0 also covers a room already deleted (the
+    /// `{"delete": true}` path removes the room before the loop ends) -
+    /// and, when this detach ended the room's live segment, how long
+    /// that segment ran.
+    ///
+    /// A stale loop whose room was meanwhile re-claimed by another
+    /// password must not decrement the new owner's count or consume its
+    /// segment; the mismatch leaves the room untouched.
+    pub async fn broadcaster_disconnected(
+        &self,
+        room: &RoomId,
+        secret: &str,
+    ) -> (usize, Option<Duration>) {
         let mut rooms = self.inner.write().await;
-        rooms.get_mut(room).map_or(0, |entry| {
+        rooms.get_mut(room).map_or((0, None), |entry| {
+            if entry.password != secret {
+                return (entry.broadcasters, None);
+            }
             entry.broadcasters = entry.broadcasters.saturating_sub(1);
-            entry.broadcasters
+            let duration = if entry.broadcasters == 0 {
+                entry.live_since.take().map(|since| since.elapsed())
+            } else {
+                None
+            };
+            (entry.broadcasters, duration)
         })
     }
 
     /// Delete a room and release its password.
     ///
     /// Deleting a room that does not exist succeeds (the caller's goal -
-    /// "this room is gone" - already holds).
+    /// "this room is gone" - already holds). Deletion cutting short a
+    /// live segment reports the segment's duration, since nobody can ask
+    /// the room afterwards; `Ok(None)` means no broadcast was live.
     #[allow(clippy::significant_drop_tightening)] // verify + remove must be one atomic step
-    pub async fn delete(&self, room: &RoomId, secret: &str) -> Result<(), Unauthorized> {
+    pub async fn delete(&self, room: &RoomId, secret: &str) -> Result<Option<Duration>, Unauthorized> {
         let mut rooms = self.inner.write().await;
         match rooms.get(room) {
             Some(entry) if entry.password != secret => Err(Unauthorized),
-            Some(_) => {
+            Some(entry) => {
+                let duration = entry.live_since.map(|since| since.elapsed());
                 rooms.remove(room);
-                Ok(())
+                Ok(duration)
             }
-            None => Ok(()),
+            None => Ok(None),
         }
     }
 


### PR DESCRIPTION
## What

The server can now report anonymous usage events to [PostHog](https://posthog.com): rooms created, broadcast durations, and viewer counts. **Off by default** — nothing is collected unless the operator sets both `SHELLSHARE_POSTHOG_KEY` and `SHELLSHARE_POSTHOG_SALT` (self-hosters get zero telemetry unless they deliberately configure their own key). `shellshare serve` hardcodes analytics off.

## Events

| Event | When | Properties |
|---|---|---|
| `room_created` | a broadcaster first claims a room | — |
| `broadcast_ended` | the room's last ingest connection detaches, or the room is deleted | `duration_seconds` (per live segment; segments sum to true broadcast time across reconnects) |
| `viewer_joined` | a socket's first join to an existing room | `user_count`, `broadcasting` (live vs replay) |

## Privacy

No IP addresses, no room names, no passwords. Broadcasters are identified by `HMAC-SHA256(salt, password)`, rooms by `HMAC-SHA256(salt, room_name)` — disjoint id spaces, so the operator can count returning users without being able to identify anyone. The secret operator salt keeps the MAC-derived default passwords safe from enumeration and custom passwords (which are room secrets) uncrackable from the analytics data. Events are sent as PostHog anonymous events with GeoIP disabled. The e2e suite asserts neither room name nor password appears in any payload.

## Reliability

Events go through a bounded channel with `try_send` (full = dropped) into a single background sender task with a 5s timeout — analytics structurally cannot block or slow the broadcast path. Broadcaster connect/disconnect bookkeeping is now password-checked, so a stale connection whose room was re-claimed by another password cannot decrement the new owner's count or misattribute its duration.

## Dependencies

`reqwest` pinned at `=0.13.3` (MSRV 1.75), built on the `ring` rustls provider already in tree — `aws-lc-rs` (and its cmake build requirement) stays out of the release builds.

## Testing

Six new e2e tests (`e2e/test_analytics.py`) against a local mock PostHog: full lifecycle with payload/PII assertions, viewer re-join dedup, dead-link joins, abrupt-disconnect and clean-exit exactly-once `broadcast_ended`, replay-viewer flagging, no-salt disablement, and `serve`-mode env-var isolation. Full suite: 210 passed / 3 skipped; `make lint` (clippy pedantic) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)