### PR TITLE
Restore PRs #113 and #114 that merged into the deleted master branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ cd e2e && uv sync && uv run pytest -n 10
 
 ## Architecture
 
-**Dual-mode binary**: `shellshare` operates as client (default) or server (`shellshare server`). `shellshare serve` combines both: it boots the embedded server on a background thread (default `localhost:3000`, configurable via `--host`/`--port`) and runs the client against it, sharing the terminal with no external server.
+**Dual-mode binary**: `shellshare` operates as client (default) or server (`shellshare server`). `shellshare serve` combines both: it boots the embedded server on a background thread (default `localhost:3000`, configurable via `--host`/`--port`) and runs the client against it, sharing the terminal with no external server. Both `serve` and `server` accept `--tunnel` (`src/tunnel.rs`): it spawns the user's pre-installed `cloudflared` against the local server, waits for the `https://*.trycloudflare.com` URL from its stderr banner, and uses it as the share link (the broadcaster still talks to localhost); missing cloudflared is a fatal error pointing at the install docs, and the tunnel process dies with shellshare.
 
 ### Client (`src/cli/`)
 Multi-threaded design ensures network latency never blocks terminal display:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ rand = "0.8"
 portable-pty = "0.8"
 
 # Ctrl+C handling (CLI)
-ctrlc = "3"
+ctrlc = { version = "3", features = ["termination"] }
 libc = "0.2.180"
 term_size = "0.3.2"
 signal-hook = "0.4.3"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,19 @@ terminal. When you're done, type `exit` or hit CTRL+D.
 
 The same `shellshare` binary also includes the server code, allowing you to broadcast your terminal to a server you control.
 
-To do so you just need to run `shellshare server` in one terminal and access [http://localhost:3000](http://localhost:3000). You can broadcast to this server using `shellshare --server http://localhost:3000`. You can use [ngrok](https://ngrok.com) to easily get a public URL to shellshare running on your local machine.
+To do so you just need to run `shellshare server` in one terminal and access [http://localhost:3000](http://localhost:3000). You can broadcast to this server using `shellshare --server http://localhost:3000`.
+
+`shellshare serve` does both at once: it starts a local server in the background and broadcasts your terminal to it.
+
+### Sharing a public link without shellshare.net
+
+Add `--tunnel` to `serve` (or `server`) to expose the local server through a [Cloudflare quick tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/do-more-with-tunnels/trycloudflare/):
+
+```bash
+shellshare serve --tunnel
+```
+
+The share link becomes a public `https://*.trycloudflare.com` URL that anyone can open, while your terminal never leaves your machine except through that tunnel. It requires [cloudflared](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/) to be installed (`brew install cloudflared` on macOS) - no Cloudflare account needed. The tunnel closes when shellshare exits.
 
 ## Installing
 

--- a/e2e/test_broadcast.py
+++ b/e2e/test_broadcast.py
@@ -424,6 +424,76 @@ def test_resize_rebuilds_browser_terminal():
         browser.close()
 
 
+def test_fullscreen_mode_scales_and_restores():
+    """
+    Pressing `f` enters fullscreen: #terminal gets the `fullscreen`
+    class and the font is rescaled to fit the viewport. Pressing `f`
+    again restores the default layout. The class is the primary signal
+    so the test holds even if headless denies native fullscreen.
+    """
+    from conftest import broadcast_message
+
+    room_id = f"test-{random_id()}"
+    password = f"secret-{random_id()}"
+
+    wait_for_server(SERVER_URL)
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(f"{SERVER_URL}/r/{room_id}")
+        page.wait_for_selector("#terminal", timeout=10000)
+        page.wait_for_function(
+            "document.getElementById('online-counter').textContent !== '0'",
+            timeout=10000
+        )
+
+        status = broadcast_message(
+            SERVER_URL, room_id, password, "fullscreen test",
+            size={"cols": 80, "rows": 24},
+        )
+        assert status == 200
+        page.wait_for_function(
+            "document.querySelectorAll('#terminal .terminal').length === 1",
+            timeout=10000,
+        )
+
+        page.keyboard.press("f")
+        page.wait_for_function(
+            "document.getElementById('terminal')"
+            ".classList.contains('fullscreen')",
+            timeout=10000,
+        )
+        # DOM contract preserved: term.js element still the only .terminal
+        assert page.evaluate(
+            "document.querySelectorAll('#terminal .terminal').length === 1"
+        )
+        # Font rescaled to fill the viewport
+        page.wait_for_function(
+            "document.querySelector('#terminal .terminal')"
+            ".style.fontSize !== ''",
+            timeout=10000,
+        )
+        font_size = page.evaluate(
+            "document.querySelector('#terminal .terminal').style.fontSize"
+        )
+        # An 80x24 terminal in a larger viewport must scale up
+        assert font_size.endswith("px") and float(font_size[:-2]) > 14
+
+        page.keyboard.press("f")
+        page.wait_for_function(
+            "!document.getElementById('terminal')"
+            ".classList.contains('fullscreen')",
+            timeout=10000,
+        )
+        assert page.evaluate(
+            "document.querySelector('#terminal .terminal')"
+            ".style.fontSize === ''"
+        )
+
+        browser.close()
+
+
 if __name__ == "__main__":
     test_happy_path_broadcast_appears_in_browser()
     test_user_counter_shows_in_browser()
@@ -432,3 +502,4 @@ if __name__ == "__main__":
     test_late_joiner_sees_history_in_browser()
     test_unicode_renders_in_browser()
     test_resize_rebuilds_browser_terminal()
+    test_fullscreen_mode_scales_and_restores()

--- a/e2e/test_cli_tunnel.py
+++ b/e2e/test_cli_tunnel.py
@@ -1,0 +1,162 @@
+"""
+E2E Tests for Shellshare CLI - --tunnel (Cloudflare quick tunnels)
+
+`--tunnel` spawns the user's cloudflared against the local server and
+prints the public trycloudflare.com URL as the share link. The suite
+never talks to Cloudflare: a stub cloudflared on PATH prints the same
+startup banner the real binary does.
+
+Test categories:
+- Share link / server log carry the tunnel URL
+- cloudflared missing or failing is a loud, actionable error
+- cloudflared dies with the shellshare process
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+import threading
+
+import pytest
+
+from conftest import CLI_PATH, _free_port, poll_until, random_id, wait_for_server
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="the stub cloudflared is a shell script"
+)
+
+STUB_URL = "https://stub-tunnel.trycloudflare.com"
+
+# What the real cloudflared prints on stderr when the quick tunnel is up
+STUB_BANNER = textwrap.dedent(f"""\
+    #!/bin/sh
+    echo $$ > "$(dirname "$0")/stub.pid"
+    echo 'INF +--------------------------------------------------------------+' >&2
+    echo 'INF |  Your quick Tunnel has been created! Visit it at:            |' >&2
+    echo 'INF |  {STUB_URL}                        |' >&2
+    echo 'INF +--------------------------------------------------------------+' >&2
+    exec sleep 600
+""")
+
+
+@pytest.fixture
+def stub_dir(tmp_path):
+    """A directory whose cloudflared prints the banner and then idles."""
+    stub = tmp_path / "cloudflared"
+    stub.write_text(STUB_BANNER)
+    stub.chmod(0o755)
+    return tmp_path
+
+
+def env_with_path(*dirs):
+    env = os.environ.copy()
+    env["PATH"] = ":".join(str(d) for d in dirs)
+    return env
+
+
+def run_serve_tunnel(env, message="hello tunnel", timeout=30, extra_args=()):
+    """Run `serve --tunnel` in stdin mode to completion."""
+    port = _free_port()
+    room = random_id()
+    proc = subprocess.run(
+        [str(CLI_PATH), "serve", "--port", str(port), "--tunnel", "--stdin",
+         "-r", room, "-W", "pw", *extra_args],
+        input=message,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=env,
+    )
+    return proc, room
+
+
+def test_serve_tunnel_share_link_uses_tunnel_url(stub_dir):
+    proc, room = run_serve_tunnel(env_with_path(stub_dir, os.environ["PATH"]))
+    assert proc.returncode == 0, proc.stderr
+    # stdin mode prints the share link to stderr
+    assert f"Sharing terminal in {STUB_URL}/r/{room}" in proc.stderr
+    # The tunnel makes the whole local server public; the user must know
+    assert "WARNING" in proc.stderr
+
+
+def test_serve_tunnel_kills_cloudflared_on_exit(stub_dir):
+    proc, _ = run_serve_tunnel(env_with_path(stub_dir, os.environ["PATH"]))
+    assert proc.returncode == 0, proc.stderr
+
+    pid = int((stub_dir / "stub.pid").read_text())
+
+    def stub_gone():
+        try:
+            os.kill(pid, 0)
+            return False
+        except ProcessLookupError:
+            return True
+
+    assert poll_until(stub_gone, timeout=5), "stub cloudflared still running"
+
+
+def test_serve_tunnel_requires_cloudflared(tmp_path):
+    # PATH with no cloudflared in it
+    proc, _ = run_serve_tunnel(env_with_path(tmp_path))
+    assert proc.returncode != 0
+    assert "cloudflared" in proc.stderr
+    assert "developers.cloudflare.com" in proc.stderr
+
+
+def test_serve_tunnel_reports_cloudflared_failure(tmp_path):
+    stub = tmp_path / "cloudflared"
+    stub.write_text(
+        "#!/bin/sh\n"
+        "echo 'ERR failed to request quick Tunnel: something broke' >&2\n"
+        "exit 1\n"
+    )
+    stub.chmod(0o755)
+    proc, _ = run_serve_tunnel(env_with_path(tmp_path, os.environ["PATH"]))
+    assert proc.returncode != 0
+    assert "cloudflared exited before reporting a tunnel URL" in proc.stderr
+    assert "failed to request quick Tunnel" in proc.stderr
+
+
+def test_server_tunnel_logs_public_url(stub_dir):
+    port = _free_port()
+    proc = subprocess.Popen(
+        [str(CLI_PATH), "server", "--host", "127.0.0.1", "--port", str(port),
+         "--tunnel"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        env=env_with_path(stub_dir, os.environ["PATH"]),
+    )
+    # Drain stdout from a thread: readline in the test body could block
+    # forever if the server never logs the URL
+    lines = []
+    reader = threading.Thread(
+        target=lambda: lines.extend(iter(proc.stdout.readline, "")), daemon=True
+    )
+    reader.start()
+    try:
+        wait_for_server(f"http://127.0.0.1:{port}")
+        assert poll_until(lambda: any(STUB_URL in line for line in lines),
+                          timeout=10), "".join(lines)
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+
+    if sys.platform == "linux":
+        # SIGTERM skips Drop, but PR_SET_PDEATHSIG must still reap the
+        # tunnel process when the server dies
+        pid = int((stub_dir / "stub.pid").read_text())
+
+        def stub_gone():
+            try:
+                os.kill(pid, 0)
+                return False
+            except ProcessLookupError:
+                return True
+
+        assert poll_until(stub_gone, timeout=5), "stub cloudflared still running"

--- a/public/stylesheet/room.css
+++ b/public/stylesheet/room.css
@@ -40,6 +40,7 @@ header {
 /* Terminals wider than the page scroll horizontally instead of
    wrapping or clipping */
 #terminal {
+  position: relative;
   overflow-x: auto;
 }
 
@@ -50,6 +51,79 @@ header {
 
 .terminal > div {
   white-space: nowrap;
+}
+
+/* Fullscreen toggle: hidden until the terminal is hovered or the
+   button is focused */
+#fullscreen-toggle {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 2;
+  width: 32px;
+  height: 32px;
+  padding: 6px;
+  border: 0;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.45);
+  color: rgba(255, 255, 255, 0.85);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+#terminal:hover #fullscreen-toggle,
+#fullscreen-toggle:focus-visible {
+  opacity: 1;
+}
+
+/* While fullscreen the button must stay reachable: touch devices have
+   no hover (and the iOS fallback has no other way out), and the
+   viewport anchoring keeps it in place when an oversized terminal
+   scrolls */
+#terminal.fullscreen #fullscreen-toggle {
+  position: fixed;
+  opacity: 0.4;
+}
+
+#terminal.fullscreen #fullscreen-toggle:hover,
+#terminal.fullscreen #fullscreen-toggle:focus-visible {
+  opacity: 1;
+}
+
+#fullscreen-toggle:hover {
+  background: rgba(0, 0, 0, 0.7);
+}
+
+#fullscreen-toggle svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+#fullscreen-toggle .icon-compress {
+  display: none;
+}
+
+#terminal.fullscreen .icon-expand {
+  display: none;
+}
+
+#terminal.fullscreen .icon-compress {
+  display: block;
+}
+
+/* Fullscreen layout, driven by the class so it works both under the
+   native Fullscreen API and as a fill-the-page fallback */
+#terminal.fullscreen {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 100;
+  overflow: auto;
+  padding: 0;
 }
 
 .reverse-video {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -28,6 +28,10 @@ fn get_terminal_size() -> TermSize {
 /// Client configuration arguments
 pub struct ClientArgs {
     pub server: String,
+    /// URL viewers should use when it differs from the broadcast URL
+    /// (e.g. a tunnel in front of the local server); the share link is
+    /// printed with this, while the transport still talks to `server`
+    pub display_server: Option<String>,
     pub room: Option<String>,
     pub password: Option<String>,
     pub stdin: bool,
@@ -78,6 +82,9 @@ fn normalize_server_url(server: &str) -> String {
 /// Run the shellshare client
 pub fn run(args: ClientArgs) -> Result<(), Box<dyn std::error::Error>> {
     let server = normalize_server_url(&args.server);
+    let share_base = args
+        .display_server
+        .map_or_else(|| server.clone(), |s| normalize_server_url(&s));
     let room = args.room.unwrap_or_else(generate_room_id);
     let password = args.password.unwrap_or_else(get_default_password);
 
@@ -86,16 +93,10 @@ pub fn run(args: ClientArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     // Connecting claims the room (or fails on a password mismatch), so
     // a broadcast that can never work is reported before the terminal
-    // is handed over to the shell
+    // is handed over to the shell. Failures must propagate (not exit):
+    // the caller may hold a tunnel whose cleanup an exit would skip
     let size = get_terminal_size();
-    let transport = match ws::Transport::connect(&server, &room_path, &password, size, args.theme)
-    {
-        Ok(transport) => transport,
-        Err(e) => {
-            eprintln!("ERROR: {e}");
-            std::process::exit(1);
-        }
-    };
+    let transport = ws::Transport::connect(&server, &room_path, &password, size, args.theme)?;
 
     // Ctrl+C only flips the flag; the sending thread owns the transport
     // and performs cleanup (flush, room deletion) when it stops
@@ -107,7 +108,7 @@ pub fn run(args: ClientArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     if args.stdin {
         // Stdin mode - print to stderr
-        eprintln!("Sharing terminal in {server}/{room_path}");
+        eprintln!("Sharing terminal in {share_base}/{room_path}");
 
         // Read from stdin and stream to server
         stream_stdin(transport, &running)?;
@@ -121,7 +122,7 @@ pub fn run(args: ClientArgs) -> Result<(), Box<dyn std::error::Error>> {
             println!("You can resize it anytime.");
         }
 
-        println!("Sharing terminal in {server}/{room_path}");
+        println!("Sharing terminal in {share_base}/{room_path}");
 
         // Run script mode with PTY
         script::run_script_mode(transport, &running)?;

--- a/src/cli/script.rs
+++ b/src/cli/script.rs
@@ -57,7 +57,9 @@ impl RawModeGuard {
                 return Self { original: None };
             }
 
-            Self { original: Some(original) }
+            Self {
+                original: Some(original),
+            }
         }
     }
 }
@@ -79,7 +81,9 @@ struct RawModeGuard;
 
 #[cfg(windows)]
 impl RawModeGuard {
-    fn new() -> Self { Self }
+    fn new() -> Self {
+        Self
+    }
 }
 
 /// Run script mode - spawn a shell in a PTY and stream output to server

--- a/src/cli/ws.rs
+++ b/src/cli/ws.rs
@@ -203,9 +203,7 @@ impl Transport {
             }
             match self.handshake() {
                 Ok(socket) => self.socket = Some(socket),
-                Err(TransportError::Unauthorized) => {
-                    return Err(TransportError::Unauthorized)
-                }
+                Err(TransportError::Unauthorized) => return Err(TransportError::Unauthorized),
                 Err(_) => return Ok(()), // retry after backoff
             }
         }
@@ -337,9 +335,7 @@ impl Transport {
 
             match tungstenite::connect(request) {
                 Ok((socket, _response)) => Ok(socket),
-                Err(WsError::Http(response))
-                    if response.status() == StatusCode::UNAUTHORIZED =>
-                {
+                Err(WsError::Http(response)) if response.status() == StatusCode::UNAUTHORIZED => {
                     Err(TransportError::Unauthorized)
                 }
                 Err(e) => Err(TransportError::Connect(e.to_string())),

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,7 +178,7 @@ fn start_local_server(host: &str, port: u16) -> Result<std::net::SocketAddr, Str
         .map_err(|e| format!("could not start local server on {host}:{port}: {e}"))
 }
 
-/// Build the analytics config from the server's PostHog flags.
+/// Build the analytics config from the server's `PostHog` flags.
 ///
 /// Both the key and the salt are required; refusing a half-configured
 /// setup beats silently degrading it (a random fallback salt would

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod cli;
 mod protocol;
 mod server;
 mod themes;
+mod tunnel;
 
 use clap::{Parser, Subcommand};
 use tracing::Level;
@@ -98,6 +99,10 @@ enum Commands {
         /// recognizable; rotating it resets all identities
         #[arg(long, env = "SHELLSHARE_POSTHOG_SALT")]
         posthog_salt: Option<String>,
+
+        /// Expose the server publicly through a Cloudflare quick tunnel (requires cloudflared)
+        #[arg(long)]
+        tunnel: bool,
     },
     /// Share your terminal through a local server (no external server needed)
     Serve {
@@ -108,6 +113,10 @@ enum Commands {
         /// Port for the local server
         #[arg(short, long, default_value = DEFAULT_PORT)]
         port: u16,
+
+        /// Share a public link through a Cloudflare quick tunnel (requires cloudflared)
+        #[arg(long)]
+        tunnel: bool,
     },
 }
 
@@ -198,6 +207,16 @@ fn analytics_config(
     }
 }
 
+/// Print a client error the way the CLI always has and exit non-zero.
+/// Call sites must drop any [`tunnel::Tunnel`] first: exiting skips
+/// destructors, so a live handle would leak cloudflared.
+fn exit_on_error(result: Result<(), Box<dyn std::error::Error>>) {
+    if let Err(e) = result {
+        eprintln!("ERROR: {e}");
+        std::process::exit(1);
+    }
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
@@ -210,6 +229,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             posthog_key,
             posthog_host,
             posthog_salt,
+            tunnel,
         }) => {
             // Initialize logging for server
             let subscriber = FmtSubscriber::builder()
@@ -221,86 +241,142 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             // Create runtime only for server mode
             let runtime = tokio::runtime::Runtime::new()?;
-            runtime.block_on(server::run(
-                &host,
-                port,
-                cleanup_interval,
-                room_ttl,
-                analytics_config,
-            ))?;
+            runtime.block_on(async {
+                let listeners = server::bind(&host, port).await?;
+                // Bind before tunneling so cloudflared forwards to the
+                // real port (`--port 0` lets the OS pick), and hold the
+                // handle for the server's lifetime: dropping it would
+                // kill cloudflared and the public URL with it
+                let _tunnel = if tunnel {
+                    let t = tunnel::start(listeners[0].local_addr()?)?;
+                    tracing::info!("Tunnel ready: rooms are public at {}/r/<room>", t.url);
+                    tracing::warn!(
+                        "anyone with that URL can view rooms and broadcast their own \
+                         through this server"
+                    );
+                    Some(t)
+                } else {
+                    None
+                };
+                server::serve_on(listeners, cleanup_interval, room_ttl, analytics_config).await
+            })?;
         }
-        Some(Commands::Serve { host, port }) => {
+        Some(Commands::Serve { host, port, tunnel }) => {
             // No tracing subscriber on purpose: the embedded server's
             // logs would garble the shared terminal
             if cli.server.trim_end_matches('/') != DEFAULT_SERVER_URL {
-                eprintln!("WARNING: --server is ignored by 'serve'; broadcasting to the local server");
-            }
-
-            let addr = match start_local_server(&host, port) {
-                Ok(addr) => addr,
-                Err(e) => {
-                    eprintln!("ERROR: {e}");
-                    std::process::exit(1);
-                }
-            };
-
-            // bind() accepts both "::1" and "[::1]"; strip brackets so
-            // the loopback check and the URL see the same host
-            let bare_host = host
-                .strip_prefix('[')
-                .and_then(|h| h.strip_suffix(']'))
-                .unwrap_or(&host);
-            let parsed_ip = bare_host.parse::<std::net::IpAddr>().ok();
-            let is_loopback = bare_host.eq_ignore_ascii_case("localhost")
-                || parsed_ip.is_some_and(|ip| ip.is_loopback());
-            let is_wildcard = parsed_ip.is_some_and(|ip| ip.is_unspecified());
-            if !is_loopback {
                 eprintln!(
-                    "WARNING: binding a non-loopback address; anyone who can reach this machine \
-                     can view this terminal and broadcast their own rooms on this server"
+                    "WARNING: --server is ignored by 'serve'; broadcasting to the local server"
                 );
-                if is_wildcard {
-                    eprintln!(
-                        "Viewers on other machines must replace 'localhost' in the link below \
-                         with this machine's address"
-                    );
-                }
             }
-
-            // Browsers can't reach wildcard addresses; point the client
-            // (and the printed share link) at localhost instead. IPv6
-            // hosts need brackets in URLs.
-            let url_host = if is_wildcard {
-                "localhost".to_string()
-            } else if bare_host.contains(':') {
-                format!("[{bare_host}]")
-            } else {
-                bare_host.to_string()
-            };
-            // Connecting the client claims the room immediately, so
-            // nobody can take the name between server start and the
-            // first broadcast
-            let args = cli::ClientArgs {
-                server: format!("http://{url_host}:{}", addr.port()),
-                room: cli.room,
-                password: cli.password,
-                stdin: cli.stdin,
-                theme: cli.theme,
-            };
-            cli::run(args)?;
+            serve(&host, port, tunnel, cli.room, cli.password, cli.stdin, cli.theme);
         }
         None => {
             // Run client mode
             let args = cli::ClientArgs {
                 server: cli.server,
+                display_server: None,
                 room: cli.room,
                 password: cli.password,
                 stdin: cli.stdin,
                 theme: cli.theme,
             };
-            cli::run(args)?;
+            exit_on_error(cli::run(args));
         }
     }
 
     Ok(())
+}
+
+/// `shellshare serve`: boot the embedded server, optionally tunnel it,
+/// and broadcast this terminal to it.
+fn serve(
+    host: &str,
+    port: u16,
+    tunnel: bool,
+    room: Option<String>,
+    password: Option<String>,
+    stdin: bool,
+    theme: Option<String>,
+) {
+    let addr = match start_local_server(host, port) {
+        Ok(addr) => addr,
+        Err(e) => {
+            eprintln!("ERROR: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    // bind() accepts both "::1" and "[::1]"; strip brackets so
+    // the loopback check and the URL see the same host
+    let bare_host = host
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host);
+    let parsed_ip = bare_host.parse::<std::net::IpAddr>().ok();
+    let is_loopback =
+        bare_host.eq_ignore_ascii_case("localhost") || parsed_ip.is_some_and(|ip| ip.is_loopback());
+    let is_wildcard = parsed_ip.is_some_and(|ip| ip.is_unspecified());
+    if !is_loopback {
+        eprintln!(
+            "WARNING: binding a non-loopback address; anyone who can reach this machine \
+             can view this terminal and broadcast their own rooms on this server"
+        );
+        if is_wildcard {
+            eprintln!(
+                "Viewers on other machines must replace 'localhost' in the link below \
+                 with this machine's address"
+            );
+        }
+    }
+
+    // Browsers can't reach wildcard addresses; point the client
+    // (and the printed share link) at localhost instead. IPv6
+    // hosts need brackets in URLs.
+    let url_host = if is_wildcard {
+        "localhost".to_string()
+    } else if bare_host.contains(':') {
+        format!("[{bare_host}]")
+    } else {
+        bare_host.to_string()
+    };
+    // The broadcaster keeps talking to the local server directly;
+    // only the share link (and so the viewers) goes through the
+    // tunnel. The handle must outlive the client: dropping it
+    // kills cloudflared and the public URL with it
+    let tunnel_handle = if tunnel {
+        match tunnel::start(addr) {
+            Ok(t) => {
+                eprintln!(
+                    "WARNING: anyone with the link below can view this terminal \
+                     and broadcast their own rooms through this server"
+                );
+                Some(t)
+            }
+            Err(e) => {
+                eprintln!("ERROR: {e}");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        None
+    };
+
+    // Connecting the client claims the room immediately, so
+    // nobody can take the name between server start and the
+    // first broadcast
+    let args = cli::ClientArgs {
+        server: format!("http://{url_host}:{}", addr.port()),
+        display_server: tunnel_handle.as_ref().map(|t| t.url.clone()),
+        room,
+        password,
+        stdin,
+        theme,
+    };
+    let result = cli::run(args);
+    // Close the tunnel before a possible exit: process::exit
+    // skips destructors, which would leave cloudflared running
+    // with the public URL pointing at a dead server
+    drop(tunnel_handle);
+    exit_on_error(result);
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -78,18 +78,6 @@ const LEGACY_CLIENT_MESSAGE: &str = "This shellshare server no longer supports b
     over HTTP POST. Your client is too old: download the latest from this server's home page \
     (it serves the binary at /bin/shellshare) and share again.";
 
-/// Run the shellshare server
-pub async fn run(
-    host: &str,
-    port: u16,
-    cleanup_interval_secs: u64,
-    room_ttl_secs: u64,
-    analytics_config: Option<AnalyticsConfig>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let listeners = bind(host, port).await?;
-    serve_on(listeners, cleanup_interval_secs, room_ttl_secs, analytics_config).await
-}
-
 /// Bind the server's TCP listeners.
 ///
 /// Separated from [`serve_on`] so callers (e.g. `shellshare serve`) can

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -1,0 +1,169 @@
+//! Public URLs for the local server via Cloudflare quick tunnels.
+//!
+//! `--tunnel` spawns the user's `cloudflared` against the local server and
+//! waits for the `https://*.trycloudflare.com` URL it prints. cloudflared
+//! is a hard requirement on purpose: downloading or bundling it ourselves
+//! would mean running a binary the user never chose to install.
+
+#![allow(unsafe_code)] // pre_exec is the only way to set PR_SET_PDEATHSIG on the child
+
+use std::io::{BufRead, BufReader, ErrorKind};
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc};
+use std::time::Duration;
+
+/// How long cloudflared gets to print the tunnel URL before giving up
+const URL_TIMEOUT: Duration = Duration::from_secs(30);
+
+const NOT_INSTALLED: &str = "--tunnel requires cloudflared, which was not found in PATH.\n\
+    Install it (macOS: brew install cloudflared) from:\n\
+    https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/";
+
+/// A quick tunnel owned by this process: dropping it kills cloudflared,
+/// which closes the public URL with the session.
+pub struct Tunnel {
+    child: Child,
+    /// Tells the stderr reader this exit is ours, so it stays quiet
+    /// instead of warning that the tunnel died
+    closing: Arc<AtomicBool>,
+    /// Public base URL, e.g. `https://lamp-grew-firms.trycloudflare.com`
+    pub url: String,
+}
+
+impl Drop for Tunnel {
+    fn drop(&mut self) {
+        self.closing.store(true, Ordering::SeqCst);
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Open a quick tunnel to the bound local address and return once the
+/// public URL is known. Every failure is a `String` ready to show the
+/// user: cloudflared missing, exiting early (its output is included), or
+/// never printing a URL.
+pub fn start(local_addr: std::net::SocketAddr) -> Result<Tunnel, String> {
+    // A wildcard bind can't be dialed; point cloudflared at the
+    // loopback of the same family instead
+    let target = if local_addr.ip().is_unspecified() {
+        let loopback: std::net::IpAddr = if local_addr.is_ipv4() {
+            std::net::Ipv4Addr::LOCALHOST.into()
+        } else {
+            std::net::Ipv6Addr::LOCALHOST.into()
+        };
+        std::net::SocketAddr::new(loopback, local_addr.port())
+    } else {
+        local_addr
+    };
+
+    let mut command = Command::new("cloudflared");
+    command
+        .args([
+            "tunnel",
+            "--url",
+            // SocketAddr's Display brackets IPv6 addresses as URLs need
+            &format!("http://{target}"),
+            "--no-autoupdate",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+
+    // Drop's kill only runs on orderly exits; a SIGTERM/SIGKILL would
+    // orphan cloudflared with the public URL still up. On Linux the
+    // kernel can deliver the kill for us when the parent dies (macOS
+    // has no pdeathsig equivalent; there `server --tunnel` relies on
+    // orderly shutdown alone).
+    // SAFETY: prctl with PR_SET_PDEATHSIG is async-signal-safe and the
+    // closure touches nothing else, as pre_exec requires post-fork
+    #[cfg(target_os = "linux")]
+    unsafe {
+        use std::os::unix::process::CommandExt;
+        command.pre_exec(|| {
+            libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM);
+            Ok(())
+        });
+    }
+
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(e) if e.kind() == ErrorKind::NotFound => return Err(NOT_INSTALLED.to_string()),
+        Err(e) => return Err(format!("could not start cloudflared: {e}")),
+    };
+
+    let Some(stderr) = child.stderr.take() else {
+        kill(&mut child);
+        return Err("could not capture cloudflared's output".to_string());
+    };
+
+    // The reader thread outlives this function: after the URL is found it
+    // keeps draining stderr so cloudflared never blocks on a full pipe
+    let closing = Arc::new(AtomicBool::new(false));
+    let closing_reader = closing.clone();
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut startup_log = Vec::new();
+        let mut found = false;
+        for line in BufReader::new(stderr).lines() {
+            let Ok(line) = line else { break };
+            if found {
+                continue;
+            }
+            if let Some(url) = extract_tunnel_url(&line) {
+                found = true;
+                let _ = tx.send(Ok(url));
+            } else {
+                startup_log.push(line);
+            }
+        }
+        // Stderr EOF after startup means cloudflared died mid-session;
+        // the terminal may be in raw mode, hence the carriage returns
+        if found && !closing_reader.load(Ordering::SeqCst) {
+            eprint!("\r\nWARNING: cloudflared exited; the public link no longer works\r\n");
+        }
+        if !found {
+            let _ = tx.send(Err(startup_log.join("\n")));
+        }
+    });
+
+    match rx.recv_timeout(URL_TIMEOUT) {
+        Ok(Ok(url)) => Ok(Tunnel {
+            child,
+            closing,
+            url,
+        }),
+        Ok(Err(output)) => {
+            kill(&mut child);
+            Err(format!(
+                "cloudflared exited before reporting a tunnel URL. Its output:\n{output}"
+            ))
+        }
+        Err(_) => {
+            kill(&mut child);
+            Err(format!(
+                "cloudflared did not report a tunnel URL within {}s",
+                URL_TIMEOUT.as_secs()
+            ))
+        }
+    }
+}
+
+/// Pick the quick-tunnel URL out of cloudflared's startup banner, e.g.
+/// `INF |  https://lamp-grew-firms.trycloudflare.com  |`
+fn extract_tunnel_url(line: &str) -> Option<String> {
+    line.split_whitespace()
+        .find(|token| {
+            token.starts_with("https://")
+                && token.ends_with(".trycloudflare.com")
+                // cloudflared logs its own API endpoint too; that one is
+                // never the tunnel
+                && !token.starts_with("https://api.")
+        })
+        .map(str::to_string)
+}
+
+fn kill(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -88,7 +88,7 @@ PS&gt; exit</span>
         <h3>Can I install it with npm?</h3>
         <p>Yes. If you have Node.js, <code>npx shellshare</code> runs it without installing anything by hand, and <code>npm install -g shellshare</code> installs it permanently. The <a href="https://www.npmjs.com/package/shellshare">npm package</a> ships the same prebuilt binaries as the downloads above.</p>
         <h3>Can I self-host shellshare?</h3>
-        <p>Yes. The shellshare binary also includes the server. You can start it by running <code>shellshare serve</code> and accessing the server at <a href="http://localhost:3000">http://localhost:3000</a>. No data leaves your computer. I suggest <a href="https://ngrok.com">ngrok</a> as an easy way to allow other people to access your server.</p>
+        <p>Yes. The shellshare binary also includes the server. You can start it by running <code>shellshare serve</code> and accessing the server at <a href="http://localhost:3000">http://localhost:3000</a>. No data leaves your computer. To let other people access your server, add <code>--tunnel</code> (e.g. <code>shellshare serve --tunnel</code>): it uses <a href="https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/">cloudflared</a> (which you need installed) to create a public <code>https://*.trycloudflare.com</code> link for your broadcast.</p>
         <h3>I found a problem! What do I do?</h3>
         <p>Please, open an issue at our <a href="https://github.com/vitorbaptista/shellshare/issues">issues page</a> describing what the problem was, your shellshare version, and your operating system.</p>
         <h3>How can I help?</h3>

--- a/templates/room.html
+++ b/templates/room.html
@@ -27,7 +27,16 @@
       </h1>
     </header>
     <div class="main">
-      <div id="terminal"></div>
+      <div id="terminal">
+        <button id="fullscreen-toggle" type="button" title="Fullscreen (f)" aria-label="Toggle fullscreen">
+          <svg class="icon-expand" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M8 3H5a2 2 0 0 0-2 2v3M16 3h3a2 2 0 0 1 2 2v3M8 21H5a2 2 0 0 1-2-2v-3M16 21h3a2 2 0 0 0 2-2v-3"/>
+          </svg>
+          <svg class="icon-compress" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M8 3v3a2 2 0 0 1-2 2H3M21 8h-3a2 2 0 0 1-2-2V3M3 16h3a2 2 0 0 1 2 2v3M16 21v-3a2 2 0 0 1 2-2h3"/>
+          </svg>
+        </button>
+      </div>
     </div>
     <footer>
       <p>shellshare is a free software (Apache License). Source code on <a href="https://github.com/vitorbaptista/shellshare">GitHub</a>.</p>
@@ -56,6 +65,7 @@
       var onlineCounterPlural = document.getElementById('online-counter-plural');
       var broadcastStatus = document.getElementById('broadcast-status');
       var terminalContainer = document.getElementById('terminal');
+      var fullscreenToggle = document.getElementById('fullscreen-toggle');
 
       if (typeof Terminal !== 'undefined') {
         Terminal.bindKeys = function() {
@@ -146,7 +156,136 @@
         }
 
         currentSize = size;
+        fitTerminal();
       }
+
+      // Fullscreen: the `fullscreen` class on #terminal drives all
+      // layout, so browsers without requestFullscreen on divs (iOS
+      // Safari) still get a fill-the-page mode. The native API only
+      // adds the OS chrome on top.
+      function isFullscreen() {
+        return terminalContainer.classList.contains('fullscreen');
+      }
+
+      function nativeFullscreenElement() {
+        return document.fullscreenElement ||
+               document.webkitFullscreenElement || null;
+      }
+
+      function enterFullscreen() {
+        terminalContainer.classList.add('fullscreen');
+        var rfs = terminalContainer.requestFullscreen ||
+                  terminalContainer.webkitRequestFullscreen;
+        if (rfs) {
+          // Older webkit doesn't return a promise
+          var result = rfs.call(terminalContainer);
+          if (result && result.catch) {
+            result.catch(function () {});
+          }
+        }
+        fitTerminal();
+      }
+
+      function exitFullscreen() {
+        if (nativeFullscreenElement()) {
+          var result = (document.exitFullscreen ||
+                        document.webkitExitFullscreen).call(document);
+          if (result && result.catch) {
+            result.catch(function () {});
+          }
+        }
+        terminalContainer.classList.remove('fullscreen');
+        fitTerminal();
+      }
+
+      function toggleFullscreen() {
+        if (isFullscreen()) {
+          exitFullscreen();
+        } else {
+          enterFullscreen();
+        }
+      }
+
+      // Scale the font so the broadcaster's cols×rows fill the screen.
+      // term.js sizing is purely font-size driven and .terminal is
+      // width: max-content, so its bounding box at the base size gives
+      // the exact ratio to scale by.
+      var MIN_FONT_PX = 7;
+      var fitScheduled = false;
+
+      function fitTerminal() {
+        if (!term) {
+          return;
+        }
+        var el = term.element;
+        el.style.fontSize = '';
+        if (!isFullscreen()) {
+          return;
+        }
+        // The stylesheet's base size, measured with the inline
+        // override cleared above
+        var baseFont = parseFloat(getComputedStyle(el).fontSize) || 14;
+        var rect = el.getBoundingClientRect();
+        var availWidth = terminalContainer.clientWidth;
+        var availHeight = terminalContainer.clientHeight;
+        if (!rect.width || !rect.height) {
+          return;
+        }
+        var scale = Math.min(availWidth / rect.width,
+                             availHeight / rect.height);
+        // Integer px keeps glyphs crisp
+        var px = Math.max(MIN_FONT_PX, Math.floor(baseFont * scale));
+        el.style.fontSize = px + 'px';
+        // Line-height rounding can push a pixel of overflow; nudge down
+        while (px > MIN_FONT_PX) {
+          rect = el.getBoundingClientRect();
+          if (rect.width <= availWidth && rect.height <= availHeight) {
+            break;
+          }
+          px -= 1;
+          el.style.fontSize = px + 'px';
+        }
+      }
+
+      function scheduleFit() {
+        if (fitScheduled) {
+          return;
+        }
+        fitScheduled = true;
+        requestAnimationFrame(function () {
+          fitScheduled = false;
+          fitTerminal();
+        });
+      }
+
+      // The native state is authoritative whenever it changes: this
+      // covers Esc and browser-UI exits, and re-syncs the class if a
+      // pending requestFullscreen resolves after a rapid toggle. The
+      // fallback path never fires this event, so its class handling
+      // is untouched.
+      function onFullscreenChange() {
+        terminalContainer.classList.toggle('fullscreen',
+                                           !!nativeFullscreenElement());
+        scheduleFit();
+      }
+
+      fullscreenToggle.addEventListener('click', toggleFullscreen);
+      window.addEventListener('resize', scheduleFit);
+      document.addEventListener('fullscreenchange', onFullscreenChange);
+      document.addEventListener('webkitfullscreenchange', onFullscreenChange);
+      document.addEventListener('keydown', function (e) {
+        if (e.defaultPrevented || e.repeat ||
+            e.ctrlKey || e.metaKey || e.altKey) {
+          return;
+        }
+        if (e.key === 'f' || e.key === 'F') {
+          toggleFullscreen();
+        } else if (e.key === 'Escape' && isFullscreen() &&
+                   !nativeFullscreenElement()) {
+          // Fallback mode only; native fullscreen handles its own Esc
+          exitFullscreen();
+        }
+      });
     })();
   </script>
 </body>


### PR DESCRIPTION
## Why

PRs #114 (fullscreen viewer) and #113 (\`--tunnel\`) were merged into \`master\` after the repo's default branch was renamed to \`main\`. The \`master\` branch has since been deleted, so their merge commits are orphaned and the features never reached \`main\` — which is why v3.0.0 shipped without them.

## What

Cherry-picks the three missing commits onto \`main\`:

- \`6a97191\` Add fullscreen mode to the web viewer (#114)
- \`69f364a\` feat: expose the local server publicly with --tunnel (#113)
- \`80c309a\` Mention --tunnel in the self-host FAQ instead of ngrok (#113)

Conflicts with the PostHog analytics and \`--theme\` work that landed on \`main\` were resolved by keeping both sides:

- \`server::run()\` is gone (tunnel needs \`bind()\` + \`serve_on()\` split); \`serve_on\` keeps its analytics parameter
- The \`server\` subcommand has both the PostHog flags and \`--tunnel\`
- \`--theme\` is threaded through the new \`serve()\` helper and the \`?\`-propagating \`Transport::connect\` call

Also fixes a pre-existing clippy \`doc_markdown\` warning on the PostHog doc comment.

\`make lint\` clean, e2e suite: 216 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)