### PR TITLE
Make npx the default install option on the home page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,11 +47,11 @@ Key files:
 Async Tokio + Axum web server with Socket.IO for real-time updates:
 - `mod.rs`: Router and HTTP/Socket.IO handlers - thin translators that delegate to the modules below
 - `rooms.rs`: All room lifecycle behind one interface - first-caller-wins password claiming, message history (max 100), canonical room names (`RoomId`), activity tracking and TTL eviction. One map, one lock: authorization and mutation are a single critical section
-- `pages.rs`: Home page (OS detection for the install command), viewer page, embedded static assets
+- `pages.rs`: Home page (install options: npx by default, plus per-OS binary downloads), viewer page, embedded static assets
 - `binaries.rs`: Platform detection and binary downloads at `/bin/shellshare`
 
 Routes:
-- `GET /` - Home page with OS detection for install command
+- `GET /` - Home page with install instructions (npx selected by default)
 - `GET /r/:room` - Viewer page
 - `GET /ws/r/:room` - WebSocket ingest (the only broadcast transport): claimed/verified at the handshake, binary frames are terminal bytes, text frames are control messages, every stored frame is acked. Each open connection counts as an attached broadcaster: viewers get a `broadcasting` Socket.IO event (current state on join, plus every transition) driving the live/offline indicator in the viewer page; a connection silent past 90s (clients ping every 30s) is treated as dead
 - `POST /r/:room` - Retired: always 410 Gone with an upgrade message, so pre-WebSocket clients fail loudly instead of silently

--- a/e2e/test_api.py
+++ b/e2e/test_api.py
@@ -9,7 +9,7 @@ claimed - or its password verified - at the WS handshake. The legacy
 POST /r/:room ingest route is retired and always returns 410 Gone.
 
 Endpoints tested:
-- GET / (home page, OS detection)
+- GET / (home page, install options)
 - GET /r/:room (room page)
 - POST /r/:room (retired: 410 Gone)
 - DELETE /r/:room (delete room)
@@ -134,75 +134,46 @@ class TestHomePage:
         assert status == 200, f"Expected 200, got {status}"
 
 
-class TestOSDetection:
-    """Tests for server-side OS detection via User-Agent header.
+class TestInstallOptions:
+    """Tests for the install option radios on the home page.
 
-    The server detects OS from User-Agent and pre-checks the corresponding radio input:
-    - User-Agent contains "windows" → id="os-windows" has checked attribute
-    - User-Agent contains "mac" → id="os-macos" has checked attribute
-    - Default (Linux or unknown) → id="os-linux" has checked attribute
+    The npx option (id="os-node") is checked by default regardless of
+    User-Agent; the per-OS binary download options are present but unchecked.
     """
 
-    def test_linux_user_agent_checks_linux_radio(self):
-        """Linux User-Agent should pre-check the os-linux radio button."""
+    def test_node_checked_by_default(self):
+        """The npx install option should be pre-checked for any User-Agent."""
         wait_for_server(SERVER_URL)
-        status, headers, body = make_request(
-            'GET', '/',
-            headers={"User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"}
-        )
-        assert status == 200, f"Expected 200, got {status}"
-        linux_input = re.search(r'<input[^>]*id="os-linux"[^>]*>', body)
-        assert linux_input, "Could not find os-linux input element"
-        assert 'checked' in linux_input.group(), f"os-linux should be checked, got: {linux_input.group()}"
+        for ua in [
+            "",
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36",
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+        ]:
+            status, headers, body = make_request('GET', '/', headers={"User-Agent": ua})
+            assert status == 200, f"Expected 200, got {status}"
+            node_input = re.search(r'<input[^>]*id="os-node"[^>]*>', body)
+            assert node_input, "Could not find os-node input element"
+            assert 'checked' in node_input.group(), \
+                f"os-node should be checked for UA {ua!r}, got: {node_input.group()}"
 
-    def test_macos_user_agent_checks_macos_radio(self):
-        """Mac User-Agent should pre-check the os-macos radio button."""
+    def test_npx_command_present(self):
+        """The npx install command should be on the page."""
         wait_for_server(SERVER_URL)
-        status, headers, body = make_request(
-            'GET', '/',
-            headers={"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"}
-        )
+        status, headers, body = make_request('GET', '/')
         assert status == 200, f"Expected 200, got {status}"
-        macos_input = re.search(r'<input[^>]*id="os-macos"[^>]*>', body)
-        assert macos_input, "Could not find os-macos input element"
-        assert 'checked' in macos_input.group(), f"os-macos should be checked, got: {macos_input.group()}"
-        # Verify os-linux is NOT checked
-        linux_input = re.search(r'<input[^>]*id="os-linux"[^>]*>', body)
-        assert linux_input, "Could not find os-linux input element"
-        assert 'checked' not in linux_input.group(), f"os-linux should NOT be checked when mac UA, got: {linux_input.group()}"
+        assert 'npx -y shellshare' in body, "Expected npx install command on home page"
 
-    def test_windows_user_agent_checks_windows_radio(self):
-        """Windows User-Agent should pre-check the os-windows radio button."""
+    def test_os_options_present_but_unchecked(self):
+        """The per-OS binary options should exist and be unchecked by default."""
         wait_for_server(SERVER_URL)
-        status, headers, body = make_request(
-            'GET', '/',
-            headers={"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
-        )
+        status, headers, body = make_request('GET', '/')
         assert status == 200, f"Expected 200, got {status}"
-        windows_input = re.search(r'<input[^>]*id="os-windows"[^>]*>', body)
-        assert windows_input, "Could not find os-windows input element"
-        assert 'checked' in windows_input.group(), f"os-windows should be checked, got: {windows_input.group()}"
-        # Verify os-linux is NOT checked
-        linux_input = re.search(r'<input[^>]*id="os-linux"[^>]*>', body)
-        assert linux_input, "Could not find os-linux input element"
-        assert 'checked' not in linux_input.group(), f"os-linux should NOT be checked when windows UA, got: {linux_input.group()}"
-
-    def test_default_checks_linux_radio(self):
-        """No/unknown User-Agent should default to pre-checking os-linux radio."""
-        wait_for_server(SERVER_URL)
-        # Test with empty/missing User-Agent
-        status, headers, body = make_request(
-            'GET', '/',
-            headers={"User-Agent": ""}
-        )
-        assert status == 200, f"Expected 200, got {status}"
-        linux_input = re.search(r'<input[^>]*id="os-linux"[^>]*>', body)
-        assert linux_input, "Could not find os-linux input element"
-        assert 'checked' in linux_input.group(), f"os-linux should be checked by default, got: {linux_input.group()}"
-        # Verify os-macos is NOT checked
-        macos_input = re.search(r'<input[^>]*id="os-macos"[^>]*>', body)
-        assert macos_input, "Could not find os-macos input element"
-        assert 'checked' not in macos_input.group(), f"os-macos should NOT be checked by default, got: {macos_input.group()}"
+        for os_id in ["os-linux", "os-macos", "os-windows"]:
+            os_input = re.search(rf'<input[^>]*id="{os_id}"[^>]*>', body)
+            assert os_input, f"Could not find {os_id} input element"
+            assert 'checked' not in os_input.group(), \
+                f"{os_id} should NOT be checked by default, got: {os_input.group()}"
 
 
 class TestRoomPage:

--- a/public/stylesheet/index.css
+++ b/public/stylesheet/index.css
@@ -29,12 +29,6 @@
   margin: 4em 0;
 }
 
-.instructions .alt-install {
-  text-align: center;
-  margin: -3em 0 4em;
-  color: #888;
-}
-
 .main h2 {
   text-transform: uppercase;
   font-size: 2em;
@@ -102,10 +96,16 @@ pre {
   font-style: italic;
 }
 
+body:has(#os-node:checked) .linux:not(.node),
+body:has(#os-node:checked) .macos:not(.node),
+body:has(#os-node:checked) .windows:not(.node),
+body:has(#os-linux:checked) .node:not(.linux),
 body:has(#os-linux:checked) .windows:not(.linux),
 body:has(#os-linux:checked) .macos:not(.linux),
+body:has(#os-macos:checked) .node:not(.macos),
 body:has(#os-macos:checked) .windows:not(.macos),
 body:has(#os-macos:checked) .linux:not(.macos),
+body:has(#os-windows:checked) .node:not(.windows),
 body:has(#os-windows:checked) .macos:not(.windows),
 body:has(#os-windows:checked) .linux:not(.windows) {
   display: none;
@@ -123,6 +123,14 @@ body:has(#os-windows:checked) .linux:not(.windows) {
 
 label[for] {
   cursor: pointer;
+}
+
+.operating-systems .node-logo {
+  height: 1.9em;
+  width: auto;
+  vertical-align: -0.25em;
+  /* the nav's letter-spacing would split the JS glyphs apart */
+  letter-spacing: normal;
 }
 
 .operating-systems input:not(:checked) + label {

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,7 +169,7 @@ fn start_local_server(host: &str, port: u16) -> Result<std::net::SocketAddr, Str
         .map_err(|e| format!("could not start local server on {host}:{port}: {e}"))
 }
 
-/// Build the analytics config from the server's PostHog flags.
+/// Build the analytics config from the server's `PostHog` flags.
 ///
 /// Both the key and the salt are required; refusing a half-configured
 /// setup beats silently degrading it (a random fallback salt would

--- a/src/server/pages.rs
+++ b/src/server/pages.rs
@@ -1,14 +1,14 @@
 //! HTML pages and static assets, embedded at compile time.
 //!
 //! Everything the browser loads that is not room data lives here: the
-//! home page (with its OS-detected install command), the viewer page,
-//! and the static assets under `public/`. The sibling `binaries` module
-//! plays the same role for the downloadable CLI binary.
+//! home page, the viewer page, and the static assets under `public/`.
+//! The sibling `binaries` module plays the same role for the
+//! downloadable CLI binary.
 
 use axum::{
     body::Body,
     extract::Path,
-    http::{header, HeaderMap, Method, Request, StatusCode},
+    http::{header, Method, Request, StatusCode},
     response::{IntoResponse, Response},
 };
 use rust_embed::Embed;
@@ -23,44 +23,11 @@ struct StaticAssets;
 #[folder = "templates/"]
 struct Templates;
 
-/// Detect OS from User-Agent header, for pre-selecting the install
-/// command on the home page
-fn detect_os_from_user_agent(user_agent: &str) -> &'static str {
-    let ua = user_agent.to_lowercase();
-    if ua.contains("windows") {
-        "windows"
-    } else if ua.contains("mac") {
-        "macos"
-    } else {
-        "linux" // default
-    }
-}
-
 /// GET / - Home page
-pub async fn index_handler(headers: HeaderMap) -> impl IntoResponse {
+pub async fn index_handler() -> impl IntoResponse {
     match Templates::get("index.html") {
         Some(content) => {
-            let user_agent = headers
-                .get(header::USER_AGENT)
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or("");
-
-            let os = detect_os_from_user_agent(user_agent);
-
-            let html = String::from_utf8_lossy(&content.data);
-            let html = html
-                .replace(
-                    "{{LINUX_CHECKED}}",
-                    if os == "linux" { " checked" } else { "" },
-                )
-                .replace(
-                    "{{MACOS_CHECKED}}",
-                    if os == "macos" { " checked" } else { "" },
-                )
-                .replace(
-                    "{{WINDOWS_CHECKED}}",
-                    if os == "windows" { " checked" } else { "" },
-                );
+            let html = String::from_utf8_lossy(&content.data).into_owned();
 
             Response::builder()
                 .status(StatusCode::OK)

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,32 +28,34 @@
       <section class="instructions">
         <div class="download">
           <code title="Click to copy">
+            <span class="node">npx -y shellshare</span>
             <span class="macos">curl -sLo shellshare https://get.shellshare.net/?os=mac &amp;&amp; chmod +x shellshare &amp;&amp; ./shellshare</span>
             <span class="linux">wget -qO shellshare https://get.shellshare.net/?os=linux &amp;&amp; chmod +x shellshare &amp;&amp; ./shellshare</span>
             <span class="windows">iwr https://get.shellshare.net/?os=windows -OutFile shellshare.exe; .\shellshare.exe</span>
           </code>
           <nav class="operating-systems">
-            <input type="radio" id="os-linux" name="os" value="linux"{{LINUX_CHECKED}}>
-            <label for="os-linux"><i class="fa fa-2x fa-linux"></i></label>
-            <input type="radio" id="os-macos" name="os" value="macos"{{MACOS_CHECKED}}>
-            <label for="os-macos"><i class="fa fa-2x fa-apple"></i></label>
-            <input type="radio" id="os-windows" name="os" value="windows"{{WINDOWS_CHECKED}}>
-            <label for="os-windows"><i class="fa fa-2x fa-windows"></i></label>
+            <input type="radio" id="os-node" name="os" value="node" checked>
+            <label for="os-node" title="Node.js"><svg class="node-logo" viewBox="0 0 28 32" aria-hidden="true" focusable="false"><polygon points="14,0 28,8 28,24 14,32 0,24 0,8" fill="currentColor"/><text x="14" y="21.5" text-anchor="middle" font-family="sans-serif" font-weight="bold" font-size="12" fill="#fff">JS</text></svg></label>
+            <input type="radio" id="os-linux" name="os" value="linux">
+            <label for="os-linux" title="Linux"><i class="fa fa-2x fa-linux"></i></label>
+            <input type="radio" id="os-macos" name="os" value="macos">
+            <label for="os-macos" title="macOS"><i class="fa fa-2x fa-apple"></i></label>
+            <input type="radio" id="os-windows" name="os" value="windows">
+            <label for="os-windows" title="Windows"><i class="fa fa-2x fa-windows"></i></label>
           </nav>
         </div>
-        <p class="alt-install">Have Node.js? Just run <code>npx shellshare</code></p>
         <h3>What is it?</h3>
         <p>Shellshare allows you to broadcast your terminal live with a single command.</p>
         <h3>How to use?</h3>
         <p>Open a terminal and write:</p>
-        <pre><code><span class="macos">$ curl -sLo shellshare https://get.shellshare.net/?os=mac
+        <pre><code><span class="node">$ npx -y shellshare</span><span class="macos">$ curl -sLo shellshare https://get.shellshare.net/?os=mac
 $ chmod +x shellshare
 $ ./shellshare</span><span class="linux">$ wget -qO shellshare https://get.shellshare.net/?os=linux
 $ chmod +x shellshare
 $ ./shellshare</span><span class="windows">PS&gt; iwr https://get.shellshare.net/?os=windows -OutFile shellshare.exe
 PS&gt; .\shellshare.exe</span>
 <span class="shell-output">Sharing terminal in https://shellshare.net/r/EPbZJ7VZNakS9vwUlS</span>
-<span class="macos linux">$ # Everything you do now will be broadcast live on the URL above.
+<span class="node macos linux">$ # Everything you do now will be broadcast live on the URL above.
 $ # When you're done, hit CTRL+D
 $ exit</span><span class="windows">PS&gt; # Everything you do now will be broadcast live on the URL above.
 PS&gt; # When you're done, hit CTRL+D
@@ -68,12 +70,12 @@ PS&gt; exit</span>
         <p>No. Shellshare was made only for live broadcasts. If you'd like to save your terminal, try <a href="https://asciinema.org">asciinema.org</a>.</p>
         <h3>Can I broadcast to a custom room name?</h3>
         <p>Yes. You can broadcast to a named room secured with a password by calling shellshare as:</p>
-        <pre><code><span class="macos">$ curl -sLo shellshare https://get.shellshare.net/?os=mac
+        <pre><code><span class="node">$ npx -y shellshare --room MY-ROOM --password MY-PASS</span><span class="macos">$ curl -sLo shellshare https://get.shellshare.net/?os=mac
 $ chmod +x shellshare &amp;&amp; ./shellshare --room MY-ROOM --password MY-PASS</span><span class="linux">$ wget -qO shellshare https://get.shellshare.net/?os=linux
 $ chmod +x shellshare &amp;&amp; ./shellshare --room MY-ROOM --password MY-PASS</span><span class="windows">PS&gt; iwr https://get.shellshare.net/?os=windows -OutFile shellshare.exe
 PS&gt; .\shellshare.exe --room MY-ROOM --password MY-PASS</span>
 <span class="shell-output">Sharing terminal in https://shellshare.net/r/MY-ROOM</span>
-<span class="macos linux">$ # ...
+<span class="node macos linux">$ # ...
 $ exit</span><span class="windows">PS&gt; # ...
 PS&gt; exit</span>
 <span class="shell-output">End of transmission.</span></code></pre>


### PR DESCRIPTION
## Summary

Now that shellshare ships on npm, the home page leads with `npx -y shellshare`:

- A Node.js hexagon (inline SVG, greys out when unselected like the Font Awesome icons) joins the install picker as the first, default-selected option showing `npx -y shellshare`.
- The Linux/macOS/Windows binary downloads remain one click away for users without Node.js.
- The "Have Node.js? Just run `npx shellshare`" footnote is removed.
- The "How to use?" and custom-room FAQ examples gained npx variants that follow the selection.
- Since npx is now the default for every visitor, server-side User-Agent OS detection for the home page is dead code: `index_handler` serves the template verbatim, and the `{{*_CHECKED}}` placeholders are gone.
- E2E: `TestOSDetection` replaced by `TestInstallOptions` (node checked for any User-Agent, npx command present, OS radios present but unchecked).
- Drive-by: fixed a pre-existing clippy `doc_markdown` warning in `main.rs`.

## Testing

- `make lint` clean.
- `e2e/test_api.py -k "HomePage or InstallOptions"`: 6 passed against a local server.
- Verified visually in a headless browser: default view shows the npx pill with the JS hexagon selected; clicking an OS icon swaps the install command and all example blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)