### PR TITLE
deploy: build from source on Dokku (fix stale deploys + PostHog)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,13 @@ RUN cargo build --release
 # Stage 2: Runtime image
 FROM debian:bookworm-slim
 
+# ca-certificates supplies the system trust store that reqwest's rustls
+# platform verifier reads root certs from; without it, the analytics HTTP
+# client fails to build (outbound HTTPS to PostHog).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 # Copy the compiled binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the Rust binary
-FROM rust:1.83-slim AS builder
+FROM rust:1-slim-bookworm AS builder
 
 WORKDIR /build
 

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,1 +1,0 @@
-FROM ghcr.io/vitorbaptista/shellshare:a43aafcbc6a921b54b7b8d54aecc82c376d0ce9d

--- a/README.md
+++ b/README.md
@@ -66,18 +66,23 @@ broadcast to this instance, use the `--server` option:
 
 ## Deploy
 
-To deploy with [Dokku](https://dokku.com/), configure it to pull from `Dockerfile.production`, which pulls the Docker image from GitHub Container Registry:
+To deploy with [Dokku](https://dokku.com/), let it build the image from
+source on each push using the project's `Dockerfile`:
 
 ```bash
 # Create the app
 dokku apps:create shellshare
 
-# Configure to pull from Dockerfile.prooduction
-dokku builder-dockerfile:set shellshare dockerfile-path Dockerfile.production
+# Build from the source Dockerfile (this is also Dokku's default)
+dokku builder-dockerfile:set shellshare dockerfile-path Dockerfile
 
-# Deploy
+# Deploy: pushes the current commit; Dokku builds and releases it
 make deploy
 ```
+
+Each `make deploy` builds the pushed commit on the Dokku host, so the
+deployed code always matches what you pushed — there is no separate image
+tag to bump.
 
 ## Analytics (optional, off by default)
 


### PR DESCRIPTION
## Why

`make deploy` was shipping stale code. Dokku deployed a **pinned image** in `Dockerfile.production` (`ghcr.io/vitorbaptista/shellshare:a43aafc`) that was 24 commits behind `main` and had to be hand-bumped every release — a step that kept getting skipped. The result: pushes were no-ops and the live site never updated.

## What changed

- **Dokku builds from source on every push.** `Dockerfile.production` is removed; deploy now uses the repo's `Dockerfile`, so the deployed code always matches the pushed commit — no image tag to bump. (Dokku side: `builder-dockerfile:set shellshare dockerfile-path Dockerfile`.)
- **Build Dockerfile fixes** surfaced once it actually built from source:
  - `rust:1.83-slim` → `rust:1-slim-bookworm`. A transitive dep (`idna_adapter`) now needs edition2024 (Rust ≥ 1.85); the bookworm variant keeps the builder's glibc matching the `debian:bookworm-slim` runtime (plain `rust:1-slim` moved to trixie and produced a binary that wouldn't start).
  - **Install `ca-certificates`** in the runtime stage. reqwest's rustls platform verifier reads roots from the system trust store; without it the analytics HTTP client failed to build, silently disabling PostHog even when configured. Analytics now reports `Analytics enabled` on startup.
- **README deploy docs** updated to match.

## Verification

Deployed to production via this branch's commits: Dokku built from source, healthchecks passed, and the server now logs `Analytics enabled, sending to https://us.i.posthog.com`. PostHog ingestion endpoint confirmed accepting the project key (HTTP 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)