### PR TITLE
fix: address Lighthouse accessibility findings

### DIFF
--- a/public/stylesheet/index.css
+++ b/public/stylesheet/index.css
@@ -92,7 +92,7 @@ pre {
 }
 
 .shell-output {
-  color: #888;
+  color: #999;
   font-style: italic;
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,7 +24,7 @@
         <h2>Live terminal broadcast</h2>
       </hgroup>
     </header>
-    <div class="main">
+    <main class="main">
       <section class="instructions">
         <div class="download">
           <code title="Click to copy">
@@ -94,7 +94,7 @@ PS&gt; exit</span>
         <h3>How can I help?</h3>
         <p>Great! Any help is appreciated. Check out the code on <a href="https://github.com/vitorbaptista/shellshare">GitHub</a> and the <a href="https://github.com/vitorbaptista/shellshare/issues">issues page</a>. If you find anything that could be improved, go ahead, create an issue and send me a pull request.</p>
       </section>
-    </div>
+    </main>
     <footer>
       <p>shellshare is a free software (Apache License). Source code on <a href="https://github.com/vitorbaptista/shellshare">GitHub</a>.</p>
       <p>Made by <a href="http://vitorbaptista.com">Vitor Baptista</a>.</p>

--- a/templates/room.html
+++ b/templates/room.html
@@ -26,7 +26,7 @@
         <a href="/"><span class="title-shell">shell</span><span class="title-share">share</span></a>
       </h1>
     </header>
-    <div class="main">
+    <main class="main">
       <div id="terminal">
         <button id="fullscreen-toggle" type="button" title="Fullscreen (f)" aria-label="Toggle fullscreen">
           <svg class="icon-expand" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -37,7 +37,7 @@
           </svg>
         </button>
       </div>
-    </div>
+    </main>
     <footer>
       <p>shellshare is a free software (Apache License). Source code on <a href="https://github.com/vitorbaptista/shellshare">GitHub</a>.</p>
       <p>Made by <a href="http://vitorbaptista.com">Vitor Baptista</a>.</p>


### PR DESCRIPTION
## Summary
Fixes the two accessibility issues from a Lighthouse audit that apply to the current code:

- **Contrast**: `.shell-output` was `#888` on the `#222` code-block background — a 4.48:1 ratio, just under WCAG AA's 4.5:1 minimum. Now `#999` (5.6:1), keeping the dimmed "program output" look.
- **Main landmark**: the home and viewer pages used `<div class="main">`; now `<main class="main">` so screen reader users get a main landmark. The class is kept, so all existing CSS still applies.

Other elements flagged by the audit (`.alt-install`, the inline `npx shellshare` code) no longer exist in the templates — the audit ran against the older deployed site, so those resolve on the next deploy.

## Test plan
- `make lint` passes
- No CSS/JS/e2e dependencies on the changed markup (OS-toggle selectors are class-based and untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)