### PR TITLE
fix: align online counter with the shellshare title in the viewer header

### DIFF
--- a/public/stylesheet/room.css
+++ b/public/stylesheet/room.css
@@ -11,7 +11,7 @@
 }
 
 .online {
-  float: right;
+  order: 1;
 }
 
 .broadcast-status::before {
@@ -29,6 +29,9 @@
 }
 
 header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   text-align: left;
 }
 


### PR DESCRIPTION
## Summary
- The "x users online" indicator in the room viewer page floated at the very top of the header, above the title line
- The header is now a flex row (`align-items: center`, `justify-content: space-between`), so the status dot and online counter sit on the same line as the "shellshare" title, vertically centered

CSS-only change in `public/stylesheet/room.css`; no markup or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)