### PR TITLE
Show broadcaster status as a colored dot with tooltip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Async Tokio + Axum web server with Socket.IO for real-time updates:
 Routes:
 - `GET /` - Home page with install instructions (npx selected by default)
 - `GET /r/:room` - Viewer page
-- `GET /ws/r/:room` - WebSocket ingest (the only broadcast transport): claimed/verified at the handshake, binary frames are terminal bytes, text frames are control messages, every stored frame is acked. Each open connection counts as an attached broadcaster: viewers get a `broadcasting` Socket.IO event (current state on join, plus every transition) driving the live/offline indicator in the viewer page; a connection silent past 90s (clients ping every 30s) is treated as dead
+- `GET /ws/r/:room` - WebSocket ingest (the only broadcast transport): claimed/verified at the handshake, binary frames are terminal bytes, text frames are control messages, every stored frame is acked. Each open connection counts as an attached broadcaster: viewers get a `broadcasting` Socket.IO event (current state on join, plus every transition) driving the online/offline indicator in the viewer page; a connection silent past 90s (clients ping every 30s) is treated as dead
 - `POST /r/:room` - Retired: always 410 Gone with an upgrade message, so pre-WebSocket clients fail loudly instead of silently
 - `DELETE /r/:room` - Cleanup room
 

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -8,6 +8,7 @@ This module provides:
 """
 
 import json
+import os
 import random
 import socket
 import string
@@ -41,7 +42,18 @@ else:
 CLI_COMMAND = [str(CLI_PATH)]
 # 127.0.0.1, not localhost: on Windows localhost can resolve to ::1 first
 # while the server listens on IPv4 (see ServerHandle.url)
-SERVER_URL = "http://127.0.0.1:3000"
+# SHELLSHARE_E2E_PORT moves the shared server off :3000, e.g. when
+# another process already occupies it
+try:
+    SHARED_PORT = int(os.environ.get("SHELLSHARE_E2E_PORT", "3000"))
+    if not 1 <= SHARED_PORT <= 65535:
+        raise ValueError
+except ValueError:
+    raise RuntimeError(
+        "SHELLSHARE_E2E_PORT must be a port number (1-65535), got: "
+        f"{os.environ['SHELLSHARE_E2E_PORT']!r}"
+    ) from None
+SERVER_URL = f"http://127.0.0.1:{SHARED_PORT}"
 
 
 def _server_responds(url, timeout=1):
@@ -79,7 +91,7 @@ def _spawn_server(port, *extra_args):
 
 
 def pytest_configure(config):
-    """Start the shared server on :3000 if none is running.
+    """Start the shared server (default :3000) if none is running.
 
     Runs only in the xdist controller (or in a single-process run), so the
     server is started exactly once no matter how many workers there are.
@@ -90,7 +102,7 @@ def pytest_configure(config):
         return
     config._shellshare_server = None
     if not _server_responds(SERVER_URL):
-        config._shellshare_server = _spawn_server(3000)
+        config._shellshare_server = _spawn_server(SHARED_PORT)
         wait_for_server(SERVER_URL)
 
 

--- a/e2e/test_broadcasting_status.py
+++ b/e2e/test_broadcasting_status.py
@@ -123,23 +123,35 @@ class TestBroadcastingStatusInBrowser:
             page = browser.new_page()
             page.goto(f"{SERVER_URL}/r/{unique_room}")
 
-            # No broadcaster yet: the join answer flips it to offline
+            # The indicator is a colored dot; the state lives in the
+            # class (color) and title (tooltip).
+            # The initial markup already says offline, so prove the
+            # join completed (we are the 1 user counted) before
+            # asserting the server-reported state
             page.wait_for_function(
-                "document.getElementById('broadcast-status').textContent === 'offline'",
+                "document.getElementById('online-counter').textContent === '1'",
+                timeout=10000,
+            )
+            page.wait_for_function(
+                "document.getElementById('broadcast-status').title === 'offline'",
                 timeout=10000,
             )
 
             ws = attach_broadcaster(unique_room, unique_password)
             try:
                 page.wait_for_function(
-                    "document.getElementById('broadcast-status').textContent === 'live'",
+                    "document.getElementById('broadcast-status').title === 'online'"
+                    " && document.getElementById('broadcast-status')"
+                    ".classList.contains('online')",
                     timeout=10000,
                 )
             finally:
                 ws.close()
 
             page.wait_for_function(
-                "document.getElementById('broadcast-status').textContent === 'offline'",
+                "document.getElementById('broadcast-status').title === 'offline'"
+                " && document.getElementById('broadcast-status')"
+                ".classList.contains('offline')",
                 timeout=10000,
             )
             browser.close()
@@ -162,7 +174,7 @@ class TestBroadcastingStatusInBrowser:
             page.goto(f"{server.url}/r/{unique_room}")
 
             page.wait_for_function(
-                "document.getElementById('broadcast-status').textContent === 'offline'",
+                "document.getElementById('broadcast-status').title === 'offline'",
                 timeout=10000,
             )
             assert page.evaluate(href).endswith("/favicon.png"), \
@@ -184,7 +196,7 @@ class TestBroadcastingStatusInBrowser:
                 ws.close()
 
             page.wait_for_function(
-                "document.getElementById('broadcast-status').textContent === 'offline'",
+                "document.getElementById('broadcast-status').title === 'offline'",
                 timeout=10000,
             )
             # Offline stops the blink and restores the regular icon; a

--- a/e2e/test_socketio.py
+++ b/e2e/test_socketio.py
@@ -29,7 +29,7 @@ import urllib.request
 import pytest
 import socketio
 
-SERVER_URL = "http://localhost:3000"
+from conftest import SERVER_URL
 
 
 def random_id(length=12):

--- a/public/stylesheet/room.css
+++ b/public/stylesheet/room.css
@@ -10,22 +10,38 @@
   font-display: swap;
 }
 
-.online {
+/* div.online, not .online: the broadcast-status span also carries an
+   `online` class when the broadcaster is live, and must not match */
+div.online {
   order: 1;
 }
 
 .broadcast-status::before {
   content: "\25CF"; /* ● */
+  /* Empty alt text: the visually hidden text inside the span carries
+     the meaning, so screen readers shouldn't announce "black circle".
+     Browsers without the alt syntax fall back to the line above. */
+  content: "\25CF" / "";
   margin-right: 0.3em;
   color: #999;
 }
 
-.broadcast-status.live::before {
+.broadcast-status.online::before {
   color: #2ecc40;
 }
 
 .broadcast-status.offline::before {
   color: #cc4030;
+}
+
+/* Present for screen readers, invisible on screen */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
 }
 
 header {

--- a/templates/room.html
+++ b/templates/room.html
@@ -18,8 +18,10 @@
   <div class="wrapper">
     <header>
       <div class="online">
-        <span id="broadcast-status" class="broadcast-status">connecting</span>
-        &middot;
+        <span id="broadcast-status" class="broadcast-status offline"
+              role="status" title="offline"><span
+              id="broadcast-status-text" class="visually-hidden"
+              >broadcaster offline</span></span>
         <span id="online-counter">0</span> user<span id="online-counter-plural">s</span> online
       </div>
       <h1 class="title">
@@ -64,6 +66,8 @@
       var onlineCounter = document.getElementById('online-counter');
       var onlineCounterPlural = document.getElementById('online-counter-plural');
       var broadcastStatus = document.getElementById('broadcast-status');
+      var broadcastStatusText =
+        document.getElementById('broadcast-status-text');
       var terminalContainer = document.getElementById('terminal');
       var fullscreenToggle = document.getElementById('fullscreen-toggle');
       var favicon = document.getElementById('favicon');
@@ -134,17 +138,23 @@
       // open, not that output is flowing). The server reports the
       // current state on join and every transition afterwards.
       socket.on('broadcasting', function (live) {
-        broadcastStatus.textContent = live ? 'live' : 'offline';
-        broadcastStatus.className =
-          'broadcast-status ' + (live ? 'live' : 'offline');
+        setBroadcastStatus(live ? 'online' : 'offline');
         setFaviconBlink(live);
       });
-      // Our own connection is down: we can't know the broadcaster's state
+      // Our own connection is down: we can't know the broadcaster's
+      // state, so report the session as offline until we rejoin
       socket.on('disconnect', function () {
-        broadcastStatus.textContent = 'connecting';
-        broadcastStatus.className = 'broadcast-status';
+        setBroadcastStatus('offline');
         setFaviconBlink(false);
       });
+
+      function setBroadcastStatus(state) {
+        broadcastStatus.title = state;
+        broadcastStatus.className = 'broadcast-status ' + state;
+        // A real (visually hidden) text node, not an aria-label:
+        // role="status" live regions only announce content changes
+        broadcastStatusText.textContent = 'broadcaster ' + state;
+      }
       socket.on('message', function (message) {
         if (term && message) {
           term.write(decoder.decode(message, {stream: true}));


### PR DESCRIPTION
## Summary

Reworks the viewer page's broadcaster status indicator:

- **Two states instead of three**: the "connecting" text state is gone. The indicator is now a colored dot — green (online) when the broadcaster is attached, red (offline) otherwise, including while the viewer's own socket is down.
- **No visible text**: the state name lives in the `title` tooltip. The `·` separator before the user counter was dropped along with the text.
- **Accessible**: the span is a `role="status"` live region with a visually hidden "broadcaster online/offline" text node (real content, so screen readers announce transitions; `aria-label` mutations are often silent). The dot glyph itself gets empty alt text (`content: "\25CF" / ""`, with a plain fallback for older browsers).
- **CSS collision fix**: the header's `float: right` rule is scoped to `div.online`, because the status span itself now carries an `online` class while broadcasting — unscoped, it floated the dot to the wrong side of the counter.

Test infrastructure improvements that fell out of this:

- `SHELLSHARE_E2E_PORT` env var moves the shared e2e server off `:3000` (default unchanged; CI untouched), validated with a clear error.
- `e2e/test_socketio.py` now imports `SERVER_URL` from conftest instead of hardcoding its own `localhost:3000` copy (which also bypassed the documented IPv6 caveat).
- The browser indicator test proves the Socket.IO join completed (via the user counter) before asserting the offline state, so the initial-markup state can't make the assertion vacuous.
- The favicon blink test (from main) updated to assert on the tooltip instead of the removed text content.

## Test plan

- [x] `make lint`
- [x] Full e2e suite after rebasing on main: 217 passed, 2 skipped
- [x] Manually verified in the browser: dot position, green/red transitions live without reload, tooltip on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)