### PR TITLE
ci: track benchmark trends and alert on regressions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,6 +16,10 @@ jobs:
     # regressions show up when comparing runs.
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      # Push trend data to the gh-pages branch and comment on regressions
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout code
@@ -59,3 +63,40 @@ jobs:
         with:
           name: benchmark-results-${{ github.sha }}
           path: e2e/bench-results.json
+
+      - name: Convert results for trend tracking
+        # github-action-benchmark's customSmallerIsBetter format: latency
+        # scenarios report p50/p95 in ms; throughput scenarios report
+        # elapsed seconds (fixed payload, so smaller is better there too)
+        run: |
+          python3 - <<'EOF'
+          import json
+
+          results = json.load(open("e2e/bench-results.json"))["results"]
+          out = []
+          for name, r in results.items():
+              if "p50_ms" in r:
+                  out.append({"name": f"{name} p50", "unit": "ms", "value": r["p50_ms"]})
+                  out.append({"name": f"{name} p95", "unit": "ms", "value": r["p95_ms"]})
+              elif "elapsed_s" in r:
+                  out.append({"name": f"{name} elapsed", "unit": "s", "value": r["elapsed_s"]})
+          json.dump(out, open("bench-trend.json", "w"), indent=2)
+          EOF
+
+      - name: Track trend and alert on regressions
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: shellshare pipeline benchmarks
+          tool: customSmallerIsBetter
+          output-file-path: bench-trend.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Only pushes to main append to the trend history; PRs compare
+          # against it read-only
+          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          save-data-file: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          # Shared runners are noisy: alert only on a 1.5x regression, and
+          # never fail the job - the comment is the signal
+          alert-threshold: "150%"
+          comment-on-alert: true
+          fail-on-alert: false
+          summary-always: true


### PR DESCRIPTION
## Summary
- The benchmark workflow dumped each run's numbers into an isolated job summary; nothing ever compared run N to run N-1 (`benchmark.py --compare` was never used in CI)
- Convert `bench-results.json` into [github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark)'s `customSmallerIsBetter` format: p50/p95 for latency scenarios (ms), elapsed seconds for throughput scenarios (fixed payload, so smaller is better everywhere)
- Pushes to main append to trend data on a `gh-pages` branch with auto-updating charts per metric; PRs compare read-only against that history
- A >1.5x regression posts a comment but never fails the job — shared runners are too noisy for hard gates, so the loose threshold + trend line is the signal

## Notes
- The first run on main creates the `gh-pages` branch. Enable GitHub Pages (source: `gh-pages`) to view charts at `/dev/bench/`; data and comments work without it
- Existing job summary and artifact upload are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)