### PR TITLE
fix: SEO/metadata quick fixes in templates

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3,12 +3,14 @@
 <head>
   <title>shellshare - live terminal broadcast</title>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Shellshare allows you to broadcast your terminal live with a single command.">
   <meta property="og:type" content="website">
   <meta property="og:title" content="shellshare: live terminal broadcast">
   <meta property="og:site_name" content="shellshare">
   <meta property="og:description" content="Shellshare allows you to broadcast your terminal live with a single command.">
-  <meta property="og:image" content="/shellshare-og-image.png">
+  <meta property="og:url" content="https://shellshare.net">
+  <meta property="og:image" content="https://shellshare.net/shellshare-og-image.png">
   <link href="https://shellshare.net" rel="canonical">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
   <link rel="stylesheet" href="/stylesheet/vendor/cssreset.css">
@@ -65,7 +67,7 @@ PS&gt; exit</span>
       <section class="faq">
         <h2>Frequently asked questions</h2>
         <h3>Can someone control my terminal through shellshare?</h3>
-        <p>No. All communication is just one-way: from your terminal to shellshare. There's no way someone could send commands to your terminal. If you'd like to allow it, try <a href="https://savannah.gnu.org/projects/screen">screen</a> or <a href="https://tmux.github.io/">tmux</a> (specially with <a href="http://tmate.io">tmate</a>).</p>
+        <p>No. All communication is just one-way: from your terminal to shellshare. There's no way someone could send commands to your terminal. If you'd like to allow it, try <a href="https://savannah.gnu.org/projects/screen">screen</a> or <a href="https://tmux.github.io/">tmux</a> (especially with <a href="https://tmate.io">tmate</a>).</p>
         <h3>Can I save the broadcast?</h3>
         <p>No. Shellshare was made only for live broadcasts. If you'd like to save your terminal, try <a href="https://asciinema.org">asciinema.org</a>.</p>
         <h3>Can I broadcast to a custom room name?</h3>
@@ -97,7 +99,7 @@ PS&gt; exit</span>
     </main>
     <footer>
       <p>shellshare is a free software (Apache License). Source code on <a href="https://github.com/vitorbaptista/shellshare">GitHub</a>.</p>
-      <p>Made by <a href="http://vitorbaptista.com">Vitor Baptista</a>.</p>
+      <p>Made by <a href="https://vitorbaptista.com">Vitor Baptista</a>.</p>
     </footer>
   </div>
   <script>

--- a/templates/room.html
+++ b/templates/room.html
@@ -3,12 +3,14 @@
 <head>
   <title>shellshare - live terminal broadcast</title>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
   <meta name="description" content="Shellshare allows you to broadcast your terminal live with a single command.">
   <meta property="og:type" content="website">
   <meta property="og:title" content="shellshare: live terminal broadcast">
   <meta property="og:site_name" content="shellshare">
   <meta property="og:description" content="Shellshare allows you to broadcast your terminal live with a single command.">
-  <meta property="og:image" content="/shellshare-og-image.png">
+  <meta property="og:image" content="https://shellshare.net/shellshare-og-image.png">
   <link rel="stylesheet" href="/stylesheet/vendor/ansi2html.css">
   <link rel="stylesheet" href="/stylesheet/room.css">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Inconsolata">
@@ -42,7 +44,7 @@
     </main>
     <footer>
       <p>shellshare is a free software (Apache License). Source code on <a href="https://github.com/vitorbaptista/shellshare">GitHub</a>.</p>
-      <p>Made by <a href="http://vitorbaptista.com">Vitor Baptista</a>.</p>
+      <p>Made by <a href="https://vitorbaptista.com">Vitor Baptista</a>.</p>
     </footer>
   </div>
   <!-- Load socket.io client from CDN -->


### PR DESCRIPTION
Quick wins from an SEO audit of shellshare.net — HTML-only changes to the two templates.

- **Viewport meta** on home and viewer pages: without it, mobile browsers render the site zoomed-out and Google's mobile-first indexing flags it as not mobile-friendly.
- **`noindex` on viewer rooms**: `robots.txt Disallow: /r/*` blocks crawling but not indexing of discovered URLs, so shared room links could be indexed as thin duplicates pointing at dead rooms.
- **Absolute `og:image` + `og:url`**: the OG spec requires absolute image URLs; the relative one meant Slack/Discord/X link previews showed no image.
- Typo fix ("specially" → "especially") and https upgrades for the tmate.io and vitorbaptista.com links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)