### PR TITLE
test: run the e2e shared server on a free port by default

### DIFF
--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -43,36 +43,6 @@ jobs:
       - name: Run E2E tests
         shell: pwsh
         run: |
-          # Start server as background job (stays alive within this step)
-          $job = Start-Job -ScriptBlock {
-            Set-Location $using:PWD
-            & ".\target\release\shellshare.exe" server --host "127.0.0.1" --port "3000"
-          }
-
-          # Wait for server to be ready
-          $timeout = 60
-          $elapsed = 0
-          while ($elapsed -lt $timeout) {
-            try {
-              $response = Invoke-WebRequest -Uri "http://127.0.0.1:3000" -UseBasicParsing -TimeoutSec 2
-              if ($response.StatusCode -eq 200) {
-                Write-Host "Server is up after $elapsed seconds"
-                break
-              }
-            } catch {
-              Write-Host "Waiting for server... ($elapsed s)"
-            }
-            Start-Sleep -Seconds 2
-            $elapsed += 2
-          }
-
-          if ($elapsed -ge $timeout) {
-            Write-Host "Server did not start within $timeout seconds"
-            Receive-Job -Id $job.Id
-            exit 1
-          }
-
-          # Run E2E tests
           cd e2e
           uv run pytest -n 10
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,24 +36,6 @@ jobs:
       - name: Build Rust binary
         run: cargo build --release
 
-      - name: Start server
-        run: |
-          ./target/release/shellshare server --host 0.0.0.0 --port 3000 &
-          sleep 2
-
-      - name: Wait for server
-        run: |
-          for i in {1..30}; do
-            if curl -s http://localhost:3000 > /dev/null; then
-              echo "Server is up after $i attempt(s)."
-              exit 0
-            fi
-            echo "Waiting for server... ($i)"
-            sleep 2
-          done
-          echo "Server did not become ready after 30 attempts."
-          exit 1
-
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ and `e2e/conftest.py`.
 
 E2E tests are the single source of truth - there are no Rust unit tests by design. The implementation is free to change as long as the e2e suite stays green.
 
-The suite in `e2e/` uses Python pytest + Playwright and manages its own servers: a shared one on :3000 (started automatically if none is running) plus per-test dedicated servers with custom flags (e.g. short `--room-ttl` for eviction tests). Coverage spans the HTTP API, Socket.IO events, full CLI-to-browser integration, real-TTY CLI sessions (`test_cli_tty.py`: resize/SIGWINCH, Ctrl+C handling, cleanup on exit), room TTL eviction, and binary downloads.
+The suite in `e2e/` uses Python pytest + Playwright and manages its own servers: a shared one started automatically on a free port (pin it with `SHELLSHARE_E2E_PORT` to reuse a pre-started server) plus per-test dedicated servers with custom flags (e.g. short `--room-ttl` for eviction tests). Coverage spans the HTTP API, Socket.IO events, full CLI-to-browser integration, real-TTY CLI sessions (`test_cli_tty.py`: resize/SIGWINCH, Ctrl+C handling, cleanup on exit), room TTL eviction, and binary downloads.
 
 # Additional instructions
 

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -78,6 +78,9 @@ def _resolve_shared_port():
     return port, False
 
 
+# _PORT_WAS_PINNED is only meaningful in the xdist controller: workers
+# always see the env var (the controller sets it) but never consult the
+# flag - they return early from pytest_configure
 SHARED_PORT, _PORT_WAS_PINNED = _resolve_shared_port()
 # 127.0.0.1, not localhost: on Windows localhost can resolve to ::1 first
 # while the server listens on IPv4 (see ServerHandle.url)
@@ -109,15 +112,19 @@ def _spawn_server(port, *extra_args):
             f"shellshare binary not found at {CLI_PATH}. "
             "Run `cargo build --release` first."
         )
-    log_path = Path(tempfile.gettempdir()) / f"shellshare-e2e-{port}.log"
-    with open(log_path, "wb") as log:
+    # mkstemp, not a fixed name: a stale log owned by another user on a
+    # shared machine would make a fixed path unopenable
+    fd, log_path = tempfile.mkstemp(
+        prefix=f"shellshare-e2e-{port}-", suffix=".log"
+    )
+    with os.fdopen(fd, "wb") as log:
         proc = subprocess.Popen(
             [str(CLI_PATH), "server", "--host", "127.0.0.1", "--port", str(port)]
             + [str(a) for a in extra_args],
             stdout=log,
             stderr=subprocess.STDOUT,
         )
-    proc.log_path = log_path
+    proc.log_path = Path(log_path)
     return proc
 
 
@@ -242,31 +249,39 @@ def poll_until(predicate, timeout=5, interval=0.1):
     return False
 
 
+def _server_log_tail(proc, limit=2000):
+    """Tail of the server's log file, or '' when unavailable."""
+    log_path = getattr(proc, "log_path", None)
+    if log_path is None:
+        return ""
+    try:
+        text = log_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    return "\n" + text[-limit:]
+
+
 def wait_for_server(url, timeout_seconds=30, proc=None):
     """Wait for server to be ready.
 
     Given the server's process, a crash before it answers fails
-    immediately with the server's output instead of timing out.
+    immediately with the server's output instead of timing out, and a
+    timeout includes that output too.
     """
     start = time.time()
     while time.time() - start < timeout_seconds:
         if proc is not None and proc.poll() is not None:
-            log_path = getattr(proc, "log_path", None)
-            output = (
-                "\n" + Path(log_path).read_text(errors="replace")[-2000:]
-                if log_path is not None
-                else ""
-            )
             raise RuntimeError(
                 f"server exited with code {proc.returncode} "
-                f"before answering at {url}{output}"
+                f"before answering at {url}{_server_log_tail(proc)}"
             )
         try:
             urllib.request.urlopen(url, timeout=1)
             return True
         except Exception:
             time.sleep(0.5)
-    raise TimeoutError(f"Server not ready after {timeout_seconds}s")
+    tail = _server_log_tail(proc) if proc is not None else ""
+    raise TimeoutError(f"Server not ready after {timeout_seconds}s{tail}")
 
 
 _UNSET = object()  # Sentinel for distinguishing None from unset

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -14,6 +14,7 @@ import socket
 import string
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import urllib.error
@@ -49,26 +50,35 @@ def _free_port():
         return s.getsockname()[1]
 
 
-# SHELLSHARE_E2E_PORT pins the shared server's port (and reuses any
-# server already answering there). Without it the suite picks a free
-# port, so whatever happens to occupy :3000 never breaks a test run.
-_env_port = os.environ.get("SHELLSHARE_E2E_PORT")
-if _env_port is not None:
-    try:
-        SHARED_PORT = int(_env_port)
-        if not 1 <= SHARED_PORT <= 65535:
-            raise ValueError
-    except ValueError:
-        raise RuntimeError(
-            "SHELLSHARE_E2E_PORT must be a port number (1-65535), got: "
-            f"{_env_port!r}"
-        ) from None
-else:
-    SHARED_PORT = _free_port()
-    # xdist workers re-import this module in fresh processes spawned
-    # after this point; the env var carries the controller's choice so
-    # every worker agrees on the port
-    os.environ["SHELLSHARE_E2E_PORT"] = str(SHARED_PORT)
+def _resolve_shared_port():
+    """Pick the shared server's port, returning (port, pinned).
+
+    SHELLSHARE_E2E_PORT pins the port (pytest_configure then reuses any
+    server already answering there). Without it the suite picks a free
+    port, so whatever happens to occupy :3000 never breaks a test run.
+    """
+    env_port = os.environ.get("SHELLSHARE_E2E_PORT")
+    if env_port is not None:
+        try:
+            port = int(env_port)
+            if not 1 <= port <= 65535:
+                raise ValueError
+        except ValueError:
+            raise RuntimeError(
+                "SHELLSHARE_E2E_PORT must be a port number (1-65535), got: "
+                f"{env_port!r}"
+            ) from None
+        return port, True
+    port = _free_port()
+    # xdist workers re-import this module in fresh local processes
+    # spawned after this point (popen gateways, xdist's default); the
+    # env var carries the controller's choice so every worker agrees
+    # on the port
+    os.environ["SHELLSHARE_E2E_PORT"] = str(port)
+    return port, False
+
+
+SHARED_PORT, _PORT_WAS_PINNED = _resolve_shared_port()
 # 127.0.0.1, not localhost: on Windows localhost can resolve to ::1 first
 # while the server listens on IPv4 (see ServerHandle.url)
 SERVER_URL = f"http://127.0.0.1:{SHARED_PORT}"
@@ -87,34 +97,47 @@ def _server_responds(url, timeout=1):
 
 
 def _spawn_server(port, *extra_args):
-    """Spawn a shellshare server process on the given port."""
+    """Spawn a shellshare server process on the given port.
+
+    Output goes to a log file (kept on the proc as `log_path`) so a
+    startup failure - e.g. the port got taken between picking it and
+    binding - is reported by wait_for_server instead of timing out
+    with no clue.
+    """
     if not CLI_PATH.exists():
         raise RuntimeError(
             f"shellshare binary not found at {CLI_PATH}. "
             "Run `cargo build --release` first."
         )
-    return subprocess.Popen(
-        [str(CLI_PATH), "server", "--host", "127.0.0.1", "--port", str(port)]
-        + [str(a) for a in extra_args],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
+    log_path = Path(tempfile.gettempdir()) / f"shellshare-e2e-{port}.log"
+    with open(log_path, "wb") as log:
+        proc = subprocess.Popen(
+            [str(CLI_PATH), "server", "--host", "127.0.0.1", "--port", str(port)]
+            + [str(a) for a in extra_args],
+            stdout=log,
+            stderr=subprocess.STDOUT,
+        )
+    proc.log_path = log_path
+    return proc
 
 
 def pytest_configure(config):
-    """Start the shared server if none is answering at SERVER_URL.
+    """Start the shared server, or adopt a pinned one already running.
 
     Runs only in the xdist controller (or in a single-process run), so the
     server is started exactly once no matter how many workers there are.
-    With SHELLSHARE_E2E_PORT pinned, a server someone already started on
-    that port is detected and left alone.
+    Reusing a running server only applies to a pinned port: an auto-picked
+    port was free moments ago, so anything answering there now is a
+    stranger that grabbed it in the meantime - spawn and let the bind
+    failure surface instead of silently testing the wrong server.
     """
     if hasattr(config, "workerinput"):  # xdist worker: controller handles it
         return
     config._shellshare_server = None
-    if not _server_responds(SERVER_URL):
-        config._shellshare_server = _spawn_server(SHARED_PORT)
-        wait_for_server(SERVER_URL)
+    if _PORT_WAS_PINNED and _server_responds(SERVER_URL):
+        return
+    config._shellshare_server = _spawn_server(SHARED_PORT)
+    wait_for_server(SERVER_URL, proc=config._shellshare_server)
 
 
 def pytest_unconfigure(config):
@@ -156,7 +179,7 @@ def dedicated_server():
         proc = _spawn_server(port, *extra_args)
         handle = ServerHandle(port=port, proc=proc)
         handles.append(handle)
-        wait_for_server(handle.url)
+        wait_for_server(handle.url, proc=proc)
         return handle
 
     yield start
@@ -219,10 +242,25 @@ def poll_until(predicate, timeout=5, interval=0.1):
     return False
 
 
-def wait_for_server(url, timeout_seconds=30):
-    """Wait for server to be ready."""
+def wait_for_server(url, timeout_seconds=30, proc=None):
+    """Wait for server to be ready.
+
+    Given the server's process, a crash before it answers fails
+    immediately with the server's output instead of timing out.
+    """
     start = time.time()
     while time.time() - start < timeout_seconds:
+        if proc is not None and proc.poll() is not None:
+            log_path = getattr(proc, "log_path", None)
+            output = (
+                "\n" + Path(log_path).read_text(errors="replace")[-2000:]
+                if log_path is not None
+                else ""
+            )
+            raise RuntimeError(
+                f"server exited with code {proc.returncode} "
+                f"before answering at {url}{output}"
+            )
         try:
             urllib.request.urlopen(url, timeout=1)
             return True

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -40,19 +40,37 @@ else:
     CLI_PATH = _DEBUG_PATH
 
 CLI_COMMAND = [str(CLI_PATH)]
+
+
+def _free_port():
+    """Ask the OS for a free TCP port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+# SHELLSHARE_E2E_PORT pins the shared server's port (and reuses any
+# server already answering there). Without it the suite picks a free
+# port, so whatever happens to occupy :3000 never breaks a test run.
+_env_port = os.environ.get("SHELLSHARE_E2E_PORT")
+if _env_port is not None:
+    try:
+        SHARED_PORT = int(_env_port)
+        if not 1 <= SHARED_PORT <= 65535:
+            raise ValueError
+    except ValueError:
+        raise RuntimeError(
+            "SHELLSHARE_E2E_PORT must be a port number (1-65535), got: "
+            f"{_env_port!r}"
+        ) from None
+else:
+    SHARED_PORT = _free_port()
+    # xdist workers re-import this module in fresh processes spawned
+    # after this point; the env var carries the controller's choice so
+    # every worker agrees on the port
+    os.environ["SHELLSHARE_E2E_PORT"] = str(SHARED_PORT)
 # 127.0.0.1, not localhost: on Windows localhost can resolve to ::1 first
 # while the server listens on IPv4 (see ServerHandle.url)
-# SHELLSHARE_E2E_PORT moves the shared server off :3000, e.g. when
-# another process already occupies it
-try:
-    SHARED_PORT = int(os.environ.get("SHELLSHARE_E2E_PORT", "3000"))
-    if not 1 <= SHARED_PORT <= 65535:
-        raise ValueError
-except ValueError:
-    raise RuntimeError(
-        "SHELLSHARE_E2E_PORT must be a port number (1-65535), got: "
-        f"{os.environ['SHELLSHARE_E2E_PORT']!r}"
-    ) from None
 SERVER_URL = f"http://127.0.0.1:{SHARED_PORT}"
 
 
@@ -66,13 +84,6 @@ def _server_responds(url, timeout=1):
         return True
     except Exception:
         return False
-
-
-def _free_port():
-    """Ask the OS for a free TCP port."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
 
 
 def _spawn_server(port, *extra_args):
@@ -91,12 +102,12 @@ def _spawn_server(port, *extra_args):
 
 
 def pytest_configure(config):
-    """Start the shared server (default :3000) if none is running.
+    """Start the shared server if none is answering at SERVER_URL.
 
     Runs only in the xdist controller (or in a single-process run), so the
     server is started exactly once no matter how many workers there are.
-    CI keeps working unchanged: it starts its own server, which we detect
-    and leave alone.
+    With SHELLSHARE_E2E_PORT pinned, a server someone already started on
+    that port is detected and left alone.
     """
     if hasattr(config, "workerinput"):  # xdist worker: controller handles it
         return

--- a/e2e/test_cli_stdin.py
+++ b/e2e/test_cli_stdin.py
@@ -222,7 +222,7 @@ class TestServerCommunication:
         )
 
         assert returncode == 0
-        assert SERVER_URL.replace("http://", "") in stderr or "localhost:3000" in stderr
+        assert SERVER_URL.replace("http://", "") in stderr
 
     def test_custom_room_name(self, unique_password):
         """--room flag should set the room name."""

--- a/e2e/test_room_cleanup.py
+++ b/e2e/test_room_cleanup.py
@@ -2,7 +2,7 @@
 E2E tests for room TTL cleanup.
 
 These need a server with a short TTL, so each test spawns its own via the
-dedicated_server fixture instead of using the shared one on :3000.
+dedicated_server fixture instead of using the shared one.
 """
 
 import time

--- a/e2e/test_theme.py
+++ b/e2e/test_theme.py
@@ -117,8 +117,9 @@ class TestThemeValidation:
 class TestThemeRendering:
     """The browser must render the broadcast in the chosen colors.
 
-    These use dedicated servers: the shared one on :3000 may be an older
-    binary whose viewer page predates themes.
+    These use dedicated servers: the shared one (when pinned to a port
+    with a pre-started server) may be an older binary whose viewer page
+    predates themes.
     """
 
     def test_theme_colors_render_in_browser(self, dedicated_server):


### PR DESCRIPTION
## Summary

The e2e suite previously assumed anything answering on :3000 was a shellshare server and reused it, so any unrelated process on that port broke every test. Now the suite picks a free OS-assigned port by default:

- The pytest-xdist controller picks a free port at conftest import time and hands it to workers through the existing `SHELLSHARE_E2E_PORT` env var (workers re-import conftest in local processes spawned after the controller sets it).
- Setting `SHELLSHARE_E2E_PORT` still pins the port and reuses a server already answering there. Reuse is now restricted to pinned ports: an auto-picked port was free moments ago, so anything answering there is a stranger that grabbed it (TOCTOU) — the suite spawns its own server and surfaces the bind failure instead of silently testing the wrong server.
- Server output goes to a per-spawn `mkstemp` log file instead of `/dev/null`; `wait_for_server` fails fast with that output when the process dies before answering, and includes it on timeout too.
- CI workflows no longer pre-start a server on :3000 — the suite's own server management covers it (~50 lines of bash/PowerShell boilerplate removed).

## Testing

- Full suite run with a non-shellshare dummy HTTP server occupying :3000 (the exact failure scenario): 216 passed, 3 skipped.
- Fail-fast path exercised manually: spawning on a busy port reports `AddrInUse` from the server log immediately instead of a bare 30s timeout.
- Two rounds of code review applied (TOCTOU reuse, log diagnostics, stale comments, dead assertion arm); final pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)