### PR TITLE
Fix #132: drop Socket.IO HTTP long-polling - it corrupts binary frames

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Key files:
 - `ws.rs`: WebSocket transport. Binary frames carry raw terminal bytes; JSON text frames carry control messages (`size`, `delete`). Reliability: output stays in a bounded replay buffer until the server acks it (`{"ack": n}`, cumulative per-connection bytes); on failure the client reconnects with backoff and replays everything unacked (at-least-once delivery). Only authorization errors are fatal
 
 ### Server (`src/server/`)
-Async Tokio + Axum web server with Socket.IO for real-time updates:
+Async Tokio + Axum web server with Socket.IO for real-time updates. Socket.IO is WebSocket-only on both ends (server config + viewer page + e2e listeners): the engine.io HTTP long-polling encoder corrupts binary events delivered to a parked long-poll, so polling is rejected outright rather than left as a fallback.
 - `mod.rs`: Router and HTTP/Socket.IO handlers - thin translators that delegate to the modules below
 - `rooms.rs`: All room lifecycle behind one interface - first-caller-wins password claiming, message history (max 100), canonical room names (`RoomId`), activity tracking and TTL eviction. One map, one lock: authorization and mutation are a single critical section
 - `pages.rs`: Home page (install options: npx by default, plus per-OS binary downloads), viewer page, embedded static assets

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -388,7 +388,9 @@ class SocketListener:
                 self._broadcasting.append(live)
                 self._condition.notify_all()
 
-        self._sio.connect(self.server_url)
+        # WebSocket only, like the viewer page: the server rejects HTTP
+        # long-polling (its engine.io polling path corrupts binary frames)
+        self._sio.connect(self.server_url, transports=["websocket"])
         self._connected = True
 
         if not wait_for_join:

--- a/e2e/test_socketio.py
+++ b/e2e/test_socketio.py
@@ -23,6 +23,7 @@ import json
 import platform
 import threading
 import time
+import urllib.error
 import urllib.parse
 import urllib.request
 
@@ -90,11 +91,29 @@ class TestSocketIOConnection:
         def connect():
             connected.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
 
         assert connected.wait(timeout=15), "Failed to connect"
 
         sio.disconnect()
+
+    def test_http_polling_is_rejected(self):
+        """The server must reject the HTTP long-polling transport.
+
+        Its engine.io polling encoder corrupts binary events delivered
+        to a parked long-poll (the attachment announce and its binary
+        payload are concatenated without the packet separator), which
+        intermittently garbled history replay for viewers. Everything
+        we ship connects WebSocket-only; polling failing loudly here
+        keeps it from being reintroduced by accident.
+        """
+        wait_for_server(SERVER_URL)
+
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            urllib.request.urlopen(
+                f"{SERVER_URL}/socket.io/?EIO=4&transport=polling", timeout=5
+            )
+        assert exc_info.value.code == 400
 
     def test_can_join_room(self):
         """Should be able to join a room."""
@@ -108,7 +127,7 @@ class TestSocketIOConnection:
         def on_users_count(count):
             user_count_received.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
 
         # Join room
         sio.emit('join', f'/r/{room_id}')
@@ -144,7 +163,7 @@ class TestSocketIOMessages:
         def on_users_count(count):
             user_count_received.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
         sio.emit('join', f'/r/{room_id}')
 
         # Wait for join to complete
@@ -186,7 +205,7 @@ class TestSocketIOMessages:
         def on_users_count(count):
             user_count_received.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
         sio.emit('join', f'/r/{room_id}')
 
         # Wait for join to complete
@@ -228,7 +247,7 @@ class TestSocketIOMessages:
             received_messages.append(data)
             message_received.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
         sio.emit('join', f'/r/{room_id}')
 
         # Wait for existing data
@@ -260,7 +279,7 @@ class TestSocketIOUserCount:
             user_counts.append(count)
             count_received.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
         sio.emit('join', f'/r/{room_id}')
 
         # Wait for user count
@@ -292,7 +311,7 @@ class TestSocketIOUserCount:
             elif count == 2:
                 count2_received.set()
 
-        sio1.connect(SERVER_URL)
+        sio1.connect(SERVER_URL, transports=["websocket"])
         sio1.emit('join', f'/r/{room_id}')
         assert count1_received.wait(timeout=15), "First client didn't receive count=1"
 
@@ -304,7 +323,7 @@ class TestSocketIOUserCount:
         def on_users_count2(count):
             sio2_joined.set()
 
-        sio2.connect(SERVER_URL)
+        sio2.connect(SERVER_URL, transports=["websocket"])
         sio2.emit('join', f'/r/{room_id}')
         assert sio2_joined.wait(timeout=15), "Second client didn't join"
 
@@ -337,7 +356,7 @@ class TestSocketIOUserCount:
             elif count == 1 and count2_received.is_set():
                 count_back_to_1.set()
 
-        sio1.connect(SERVER_URL)
+        sio1.connect(SERVER_URL, transports=["websocket"])
         sio1.emit('join', f'/r/{room_id}')
         assert count1_received.wait(timeout=15), "First client didn't receive count=1"
 
@@ -349,7 +368,7 @@ class TestSocketIOUserCount:
         def on_users_count2(count):
             sio2_joined.set()
 
-        sio2.connect(SERVER_URL)
+        sio2.connect(SERVER_URL, transports=["websocket"])
         sio2.emit('join', f'/r/{room_id}')
         assert sio2_joined.wait(timeout=15), "Second client didn't join"
         assert count2_received.wait(timeout=15), "First client didn't receive count=2"
@@ -389,7 +408,7 @@ class TestSocketIOMultipleRooms:
         def on_users_count1(count):
             sio1_joined.set()
 
-        sio1.connect(SERVER_URL)
+        sio1.connect(SERVER_URL, transports=["websocket"])
         sio1.emit('join', f'/r/{room_id1}')
         assert sio1_joined.wait(timeout=15), "Client 1 didn't join"
 
@@ -406,7 +425,7 @@ class TestSocketIOMultipleRooms:
         def on_users_count2(count):
             sio2_joined.set()
 
-        sio2.connect(SERVER_URL)
+        sio2.connect(SERVER_URL, transports=["websocket"])
         sio2.emit('join', f'/r/{room_id2}')
         assert sio2_joined.wait(timeout=15), "Client 2 didn't join"
 
@@ -459,7 +478,7 @@ class TestSocketIOMessageAccumulation:
             received_messages.append(data)
             message_received.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
         sio.emit('join', f'/r/{room_id}')
 
         # Wait for existing data
@@ -501,7 +520,7 @@ class TestSocketIOJoinEdgeCases:
         def on_users_count(count):
             user_count_received.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
         # Join WITHOUT the /r/ prefix
         sio.emit('join', room_id)
 
@@ -552,7 +571,7 @@ class TestSocketIOJoinEdgeCases:
         def on_users_count(count):
             user_count_received.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
         # Join WITH the /r/ prefix (standard way)
         sio.emit('join', f'/r/{room_id}')
 
@@ -588,7 +607,7 @@ class TestSocketIOJoinEdgeCases:
         def connect_error(data):
             error_occurred.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
         assert connected.wait(timeout=15), "Failed to connect"
 
         # Join with empty string - should not crash
@@ -617,7 +636,7 @@ class TestSocketIOJoinEdgeCases:
             user_counts.append(count)
             count_received.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
         sio.emit('join', room_id)
 
         # Wait for user count (indicates successful join)
@@ -666,7 +685,7 @@ class TestSocketIOMultipleRoomJoin:
             if join_count[0] >= 2:  # Both rooms joined
                 joins_complete.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
 
         # Join both rooms
         sio.emit('join', f'/r/{room_id1}')
@@ -703,7 +722,7 @@ class TestSocketIOMultipleRoomJoin:
             counts1.append(count)
             sio1_joined.set()
 
-        sio1.connect(SERVER_URL)
+        sio1.connect(SERVER_URL, transports=["websocket"])
         sio1.emit('join', f'/r/{room_id1}')
         assert sio1_joined.wait(timeout=15), "Client 1 didn't join"
 
@@ -717,7 +736,7 @@ class TestSocketIOMultipleRoomJoin:
             counts2.append(count)
             sio2_joined.set()
 
-        sio2.connect(SERVER_URL)
+        sio2.connect(SERVER_URL, transports=["websocket"])
         sio2.emit('join', f'/r/{room_id2}')
         assert sio2_joined.wait(timeout=15), "Client 2 didn't join"
 
@@ -749,7 +768,7 @@ class TestSocketIOReconnection:
             counts1.append(count)
             sio1_joined.set()
 
-        sio1.connect(SERVER_URL)
+        sio1.connect(SERVER_URL, transports=["websocket"])
         sio1.emit('join', f'/r/{room_id}')
         assert sio1_joined.wait(timeout=15), "First join failed"
 
@@ -768,7 +787,7 @@ class TestSocketIOReconnection:
             counts2.append(count)
             sio2_joined.set()
 
-        sio2.connect(SERVER_URL)
+        sio2.connect(SERVER_URL, transports=["websocket"])
         sio2.emit('join', f'/r/{room_id}')
         assert sio2_joined.wait(timeout=15), "Rejoin failed"
 
@@ -799,7 +818,7 @@ class TestSocketIOReconnection:
             messages1.append(data)
             msg_received1.set()
 
-        sio1.connect(SERVER_URL)
+        sio1.connect(SERVER_URL, transports=["websocket"])
         sio1.emit('join', f'/r/{room_id}')
 
         assert msg_received1.wait(timeout=15), "First client should receive message"
@@ -815,7 +834,7 @@ class TestSocketIOReconnection:
             messages2.append(data)
             msg_received2.set()
 
-        sio2.connect(SERVER_URL)
+        sio2.connect(SERVER_URL, transports=["websocket"])
         sio2.emit('join', f'/r/{room_id}')
 
         assert msg_received2.wait(timeout=15), "Second client should receive message"
@@ -850,7 +869,7 @@ class TestSocketIOEdgeCases:
             elif join_count[0] >= 2:
                 second_join.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
 
         # Join same room twice
         sio.emit('join', f'/r/{room_id}')
@@ -890,7 +909,7 @@ class TestSocketIOEdgeCases:
         def on_users_count(count):
             user_count_received.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
         # Use encoded room for Socket.IO too (server uses req.url which keeps encoding)
         sio.emit('join', f'/r/{encoded_room_id}')
 
@@ -922,7 +941,7 @@ class TestSocketIOEdgeCases:
             user_counts.append(count)
             count_received.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
         sio.emit('join', f'/r/{room_id}')
 
         # Should either work or fail gracefully
@@ -958,7 +977,7 @@ class TestSocketIOEdgeCases:
         def on_users_count(count):
             user_count_received.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
         sio.emit('join', f'/r/{room_id}')
 
         assert user_count_received.wait(timeout=15), "Join failed"
@@ -979,7 +998,7 @@ class TestSocketIOEdgeCases:
         wait_for_server(SERVER_URL)
 
         sio = socketio.Client()
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
 
         # Rapidly join different rooms
         for i in range(10):
@@ -1018,7 +1037,7 @@ class TestSocketIOEdgeCases:
         def on_users_count(count):
             user_count_received.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
         sio.emit('join', f'/r/{room_id}')
 
         assert user_count_received.wait(timeout=15), "Join failed"
@@ -1076,7 +1095,7 @@ class TestSocketIOEventOrder:
             if 'size' in event_types and 'message' in event_types and 'usersCount' in event_types:
                 all_received.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
 
         # A bare emit has no delivery guarantee and a lost join means zero
         # events ever arrive. Re-joining is idempotent (same pattern as
@@ -1122,7 +1141,7 @@ class TestSocketIOEventOrder:
             sizes.append(data)
             size_received.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
         sio.emit('join', f'/r/{room_id}')
 
         assert size_received.wait(timeout=15), "Size not received"
@@ -1161,7 +1180,7 @@ class TestSocketIOEmptyRoom:
             user_counts.append(count)
             events_done.set()  # usersCount is always sent
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
         sio.emit('join', f'/r/{room_id}')
 
         # Wait for usersCount (always sent)
@@ -1213,7 +1232,7 @@ class TestSocketIOEmptyRoom:
             user_counts.append(count)
             count_received.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
         sio.emit('join', f'/r/{room_id}')
 
         # Wait for usersCount
@@ -1263,7 +1282,7 @@ class TestSocketIOSizePassthrough:
         def on_users_count(count):
             user_count_received.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
         sio.emit('join', f'/r/{room_id}')
 
         assert user_count_received.wait(timeout=15), "Join failed"
@@ -1304,7 +1323,7 @@ class TestSocketIOSizePassthrough:
         def on_users_count(count):
             user_count_received.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
         sio.emit('join', f'/r/{room_id}')
 
         assert user_count_received.wait(timeout=15), "Join failed"
@@ -1345,7 +1364,7 @@ class TestSocketIOMessageFormat:
         def on_users_count(count):
             user_count_received.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
         sio.emit('join', f'/r/{room_id}')
 
         assert user_count_received.wait(timeout=15), "Join failed"
@@ -1386,7 +1405,7 @@ class TestSocketIOMessageFormat:
             messages.append(data)
             message_received.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
         sio.emit('join', f'/r/{room_id}')
 
         assert message_received.wait(timeout=15), "Message not received"
@@ -1446,8 +1465,8 @@ class TestSocketIOStripPrefix:
         def on_count2(count):
             sio2_joined.set()
 
-        sio1.connect(SERVER_URL)
-        sio2.connect(SERVER_URL)
+        sio1.connect(SERVER_URL, transports=["websocket"])
+        sio2.connect(SERVER_URL, transports=["websocket"])
 
         # One joins with /r/ prefix
         sio1.emit('join', f'/r/{room_id}')
@@ -1501,7 +1520,7 @@ class TestSocketIOLargeMessage:
         def on_users_count(count):
             user_count_received.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
         sio.emit('join', f'/r/{room_id}')
 
         assert user_count_received.wait(timeout=15), "Join failed"
@@ -1552,7 +1571,7 @@ class TestSocketIOMultipleClients:
 
             sio.on('message', make_msg_handler(messages, msg_evt))
             sio.on('usersCount', make_join_handler(join_evt))
-            sio.connect(SERVER_URL)
+            sio.connect(SERVER_URL, transports=["websocket"])
             sio.emit('join', f'/r/{room_id}')
 
             clients.append(sio)
@@ -1610,7 +1629,7 @@ class TestSocketIOLateJoinerHistory:
             received_messages.append(data)
             message_received.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
         sio.emit('join', f'/r/{room_id}')
 
         # Should receive the historical message
@@ -1645,7 +1664,7 @@ class TestSocketIOLateJoinerHistory:
             received_messages.append(data)
             message_received.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
         sio.emit('join', f'/r/{room_id}')
 
         # Should receive the accumulated history
@@ -1691,7 +1710,7 @@ class TestSocketIOLateJoinerHistory:
         def on_live_count(count):
             live_ready.set()
 
-        live_viewer.connect(SERVER_URL)
+        live_viewer.connect(SERVER_URL, transports=["websocket"])
         live_viewer.emit('join', f'/r/{room_id}')
 
         # Wait for live viewer to be ready
@@ -1715,7 +1734,7 @@ class TestSocketIOLateJoinerHistory:
             late_messages.append(decode_message(data))
             late_received.set()
 
-        late_joiner.connect(SERVER_URL)
+        late_joiner.connect(SERVER_URL, transports=["websocket"])
         late_joiner.emit('join', f'/r/{room_id}')
 
         # Wait for late joiner to receive history
@@ -1755,7 +1774,7 @@ class TestSocketIOLateJoinerHistory:
             received_sizes.append(data)
             size_received.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
         sio.emit('join', f'/r/{room_id}')
 
         # Should receive the size
@@ -1799,7 +1818,7 @@ class TestSocketIOLateJoinerHistory:
             if 'size' in event_types and 'message' in event_types:
                 all_received.set()
 
-        sio.connect(SERVER_URL)
+        sio.connect(SERVER_URL, transports=["websocket"])
 
         # Same confirmed-join pattern as SocketListener.connect: a lost
         # join would mean zero events; re-joining is idempotent

--- a/e2e/test_theme.py
+++ b/e2e/test_theme.py
@@ -165,7 +165,7 @@ class TestThemeRendering:
             ],
             stdin=subprocess.PIPE,
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,  # DIAGNOSTICS #132: capture CLI errors
             text=True,
         )
         try:
@@ -176,17 +176,48 @@ class TestThemeRendering:
             with sync_playwright() as p:
                 browser = p.chromium.launch()
                 page = browser.new_page()
+                # TEMPORARY DIAGNOSTICS for issue #132
+                console_lines = []
+                page.on(
+                    "console",
+                    lambda m: console_lines.append(f"{m.type}: {m.text}"),
+                )
                 page.goto(f"{server.url}/r/{room_id}")
                 page.wait_for_selector("#terminal", timeout=10000)
 
-                expect(page.locator("#terminal")).to_contain_text(
-                    "early content", timeout=10000
-                )
-                assert terminal_background(page) == SOLARIZED_LIGHT_BG
+                try:
+                    expect(page.locator("#terminal")).to_contain_text(
+                        "early content", timeout=10000
+                    )
+                    assert terminal_background(page) == SOLARIZED_LIGHT_BG
+                except AssertionError:
+                    # TEMPORARY DIAGNOSTICS for issue #132: dump every
+                    # observable on failure, in raw byte-level form
+                    rxlog = page.evaluate("window.__rxLog || []")
+                    print("=== DIAG #132: page rxlog ===")
+                    for line in rxlog:
+                        print(" ", line)
+                    print("=== DIAG #132: page console ===")
+                    for line in console_lines:
+                        print(" ", line)
+                    print("=== DIAG #132: server log tail ===")
+                    try:
+                        print(server.proc.log_path.read_text(
+                            encoding="utf-8", errors="backslashreplace"
+                        )[-4000:])
+                    except OSError as e:
+                        print("  unreadable:", e)
+                    raise
                 browser.close()
         finally:
             proc.stdin.close()
-            proc.wait(timeout=10)
+            try:
+                proc.wait(timeout=10)
+            finally:
+                stderr_tail = proc.stderr.read() if proc.stderr else ""
+                if stderr_tail.strip():
+                    print("=== DIAG #132: CLI stderr ===")
+                    print(stderr_tail[-2000:])
 
     def test_tango_colors_without_theme_flag(self, dedicated_server):
         server = dedicated_server()

--- a/e2e/test_theme.py
+++ b/e2e/test_theme.py
@@ -165,7 +165,7 @@ class TestThemeRendering:
             ],
             stdin=subprocess.PIPE,
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,  # DIAGNOSTICS #132: capture CLI errors
+            stderr=subprocess.DEVNULL,
             text=True,
         )
         try:
@@ -176,48 +176,17 @@ class TestThemeRendering:
             with sync_playwright() as p:
                 browser = p.chromium.launch()
                 page = browser.new_page()
-                # TEMPORARY DIAGNOSTICS for issue #132
-                console_lines = []
-                page.on(
-                    "console",
-                    lambda m: console_lines.append(f"{m.type}: {m.text}"),
-                )
                 page.goto(f"{server.url}/r/{room_id}")
                 page.wait_for_selector("#terminal", timeout=10000)
 
-                try:
-                    expect(page.locator("#terminal")).to_contain_text(
-                        "early content", timeout=10000
-                    )
-                    assert terminal_background(page) == SOLARIZED_LIGHT_BG
-                except AssertionError:
-                    # TEMPORARY DIAGNOSTICS for issue #132: dump every
-                    # observable on failure, in raw byte-level form
-                    rxlog = page.evaluate("window.__rxLog || []")
-                    print("=== DIAG #132: page rxlog ===")
-                    for line in rxlog:
-                        print(" ", line)
-                    print("=== DIAG #132: page console ===")
-                    for line in console_lines:
-                        print(" ", line)
-                    print("=== DIAG #132: server log tail ===")
-                    try:
-                        print(server.proc.log_path.read_text(
-                            encoding="utf-8", errors="backslashreplace"
-                        )[-4000:])
-                    except OSError as e:
-                        print("  unreadable:", e)
-                    raise
+                expect(page.locator("#terminal")).to_contain_text(
+                    "early content", timeout=10000
+                )
+                assert terminal_background(page) == SOLARIZED_LIGHT_BG
                 browser.close()
         finally:
             proc.stdin.close()
-            try:
-                proc.wait(timeout=10)
-            finally:
-                stderr_tail = proc.stderr.read() if proc.stderr else ""
-                if stderr_tail.strip():
-                    print("=== DIAG #132: CLI stderr ===")
-                    print(stderr_tail[-2000:])
+            proc.wait(timeout=10)
 
     def test_tango_colors_without_theme_flag(self, dedicated_server):
         server = dedicated_server()

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -202,8 +202,16 @@ pub async fn serve_on(
 }
 
 /// Setup Socket.IO event handlers
+///
+/// The connect handler MUST stay synchronous: socketioxide sends the
+/// connect ack to the client and only then runs this handler - an async
+/// handler is tokio::spawn'ed, so under load a client's first `join`
+/// (emitted as soon as it sees the ack) could arrive before
+/// `socket.on("join")` is registered and be silently dropped, leaving a
+/// viewer stuck on an empty terminal. A sync handler registers
+/// everything inline before the connect task yields.
 fn setup_socket_handlers(io: &SocketIo) {
-    io.ns("/", |socket: SocketRef, _state: SioState<AppState>| async move {
+    io.ns("/", |socket: SocketRef, _state: SioState<AppState>| {
         info!("Client connected: {}", socket.id);
 
         // Handle join event
@@ -240,11 +248,15 @@ fn setup_socket_handlers(io: &SocketIo) {
                 // Release before the room snapshot below takes its own lock
                 drop(socket_rooms);
 
-                // Catch the viewer up if the room is live
+                // Catch the viewer up if the room is live - but only on
+                // the socket's FIRST join to this room: clients re-emit
+                // `join` until they see the usersCount confirmation, and
+                // replaying history for a retry that merely overtook a
+                // slow confirmation would duplicate terminal content
                 let snapshot = state.rooms.snapshot(&room_id).await;
                 let room_exists = snapshot.is_some();
                 let broadcasting = snapshot.as_ref().is_some_and(|s| s.broadcasting);
-                if let Some(snapshot) = snapshot {
+                if let Some(snapshot) = snapshot.filter(|_| newly_joined) {
                     // Send size FIRST - terminal must be sized before receiving content
                     if let Some(ref size) = snapshot.size {
                         if let Err(e) = socket.emit("size", size) {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -147,8 +147,16 @@ pub async fn serve_on(
         ..Default::default()
     };
 
-    // Socket.IO setup
+    // Socket.IO setup. WebSocket only, no HTTP long-polling: the
+    // engine.io polling encoder corrupts binary events when an emit
+    // lands on a parked long-poll (the announce and its attachment are
+    // concatenated without the packet separator - engineioxide bug,
+    // still present in 0.17.3), which intermittently garbled history
+    // replay and live output for viewers. Every consumer is ours (the
+    // viewer page below connects websocket-only), so there is nothing
+    // that needs the fallback.
     let (sio_layer, io) = SocketIo::builder()
+        .transports([socketioxide::TransportType::Websocket])
         .with_state(app_state.clone())
         .build_layer();
 

--- a/templates/room.html
+++ b/templates/room.html
@@ -59,6 +59,52 @@
       // the polling-then-upgrade dance avoids its races entirely
       var socket = io({transports: ['websocket']});
       var room = window.location.pathname;
+
+      // TEMPORARY DIAGNOSTICS for issue #132: timestamped log of every
+      // socket lifecycle event and payload, readable by the e2e suite
+      // via window.__rxLog. Remove once the Windows flake is diagnosed.
+      var RXLOG = [];
+      window.__rxLog = RXLOG;
+      function rxlog(kind, info) {
+        RXLOG.push(Date.now() + ' ' + kind + ' ' + info);
+        if (RXLOG.length > 300) { RXLOG.shift(); }
+      }
+      function hexdump(buf) {
+        var bytes = new Uint8Array(buf);
+        var head = [];
+        for (var i = 0; i < Math.min(bytes.length, 48); i++) {
+          head.push(bytes[i].toString(16).padStart(2, '0'));
+        }
+        return 'len=' + bytes.length + ' ' + head.join('');
+      }
+      rxlog('page-load', location.href);
+      socket.io.on('error', function (e) { rxlog('mgr-error', String(e)); });
+      socket.io.on('reconnect_attempt', function (n) {
+        rxlog('reconnect-attempt', n);
+      });
+      socket.io.engine.on('close', function (reason) {
+        rxlog('engine-close', String(reason));
+      });
+      socket.on('connect_error', function (e) {
+        rxlog('connect-error', String(e && e.message || e));
+      });
+      socket.on('disconnect', function (reason) {
+        rxlog('socket-disconnect', String(reason));
+      });
+      socket.on('connect', function () {
+        rxlog('connect', socket.id + ' via ' +
+              socket.io.engine.transport.name);
+      });
+      socket.on('message', function (m) {
+        try { rxlog('message', hexdump(m)); }
+        catch (e) { rxlog('message-unhexable', String(e) + ' ' + typeof m); }
+      });
+      socket.on('size', function (s) {
+        rxlog('size', JSON.stringify(s));
+      });
+      socket.on('broadcasting', function (b) { rxlog('broadcasting', b); });
+      socket.on('usersCount', function (n) { rxlog('usersCount', n); });
+      // END TEMPORARY DIAGNOSTICS
       var term;
       var currentSize = {};
       // Messages are binary: raw terminal bytes, decoded as one
@@ -112,6 +158,24 @@
       // Join on every connect: socket.io reconnects by itself after a
       // network blip, but room membership is lost server-side, so a
       // viewer that doesn't re-join goes silently dead.
+      //
+      // The join must be confirmed, not fire-and-forget: a bare emit
+      // can be lost (e.g. it reaches the server before the connection
+      // handler finished registering events), and a viewer whose join
+      // vanished would stare at an empty terminal forever. The server
+      // answers every join with usersCount, re-joining is idempotent,
+      // and the history catch-up is only sent for a socket's first
+      // join - so emit and re-emit until confirmed.
+      var joinConfirmed = false;
+      var joinTimer = null;
+      function joinUntilConfirmed() {
+        joinTimer = null;
+        if (joinConfirmed || !socket.connected) {
+          return;
+        }
+        socket.emit('join', room);
+        joinTimer = setTimeout(joinUntilConfirmed, 500);
+      }
       socket.on('connect', function () {
         if (joinedBefore) {
           // The server replays the room history on join; start from a
@@ -125,9 +189,14 @@
           onSize({cols: 80, rows: 30});
         }
         joinedBefore = true;
-        socket.emit('join', room);
+        joinConfirmed = false;
+        if (joinTimer) {
+          clearTimeout(joinTimer);
+        }
+        joinUntilConfirmed();
       });
       socket.on('usersCount', function (onlineUsers) {
+        joinConfirmed = true;
         onlineCounter.innerHTML = onlineUsers;
         if (onlineUsers == 1) {
           onlineCounterPlural.innerHTML = '';

--- a/templates/room.html
+++ b/templates/room.html
@@ -59,52 +59,6 @@
       // the polling-then-upgrade dance avoids its races entirely
       var socket = io({transports: ['websocket']});
       var room = window.location.pathname;
-
-      // TEMPORARY DIAGNOSTICS for issue #132: timestamped log of every
-      // socket lifecycle event and payload, readable by the e2e suite
-      // via window.__rxLog. Remove once the Windows flake is diagnosed.
-      var RXLOG = [];
-      window.__rxLog = RXLOG;
-      function rxlog(kind, info) {
-        RXLOG.push(Date.now() + ' ' + kind + ' ' + info);
-        if (RXLOG.length > 300) { RXLOG.shift(); }
-      }
-      function hexdump(buf) {
-        var bytes = new Uint8Array(buf);
-        var head = [];
-        for (var i = 0; i < Math.min(bytes.length, 48); i++) {
-          head.push(bytes[i].toString(16).padStart(2, '0'));
-        }
-        return 'len=' + bytes.length + ' ' + head.join('');
-      }
-      rxlog('page-load', location.href);
-      socket.io.on('error', function (e) { rxlog('mgr-error', String(e)); });
-      socket.io.on('reconnect_attempt', function (n) {
-        rxlog('reconnect-attempt', n);
-      });
-      socket.io.engine.on('close', function (reason) {
-        rxlog('engine-close', String(reason));
-      });
-      socket.on('connect_error', function (e) {
-        rxlog('connect-error', String(e && e.message || e));
-      });
-      socket.on('disconnect', function (reason) {
-        rxlog('socket-disconnect', String(reason));
-      });
-      socket.on('connect', function () {
-        rxlog('connect', socket.id + ' via ' +
-              socket.io.engine.transport.name);
-      });
-      socket.on('message', function (m) {
-        try { rxlog('message', hexdump(m)); }
-        catch (e) { rxlog('message-unhexable', String(e) + ' ' + typeof m); }
-      });
-      socket.on('size', function (s) {
-        rxlog('size', JSON.stringify(s));
-      });
-      socket.on('broadcasting', function (b) { rxlog('broadcasting', b); });
-      socket.on('usersCount', function (n) { rxlog('usersCount', n); });
-      // END TEMPORARY DIAGNOSTICS
       var term;
       var currentSize = {};
       // Messages are binary: raw terminal bytes, decoded as one

--- a/templates/room.html
+++ b/templates/room.html
@@ -54,7 +54,10 @@
 
       // Theme definitions injected by the server from themes.json
       var THEMES = {{THEMES_JSON}};
-      var socket = io();
+      // WebSocket only - the server rejects HTTP long-polling (its
+      // engine.io polling path corrupts binary frames), and skipping
+      // the polling-then-upgrade dance avoids its races entirely
+      var socket = io({transports: ['websocket']});
       var room = window.location.pathname;
       var term;
       var currentSize = {};


### PR DESCRIPTION
## TL;DR

The "invalid UTF-8 from history replay" was two separate bugs plus one log-encoding illusion:

1. **The `�` wall in CI logs is an EMPTY terminal, not corruption.** The runs of exactly 2400 `U+FFFD` equal the default 80×30 grid: term.js pads blank cells with `U+00A0`, pytest on Windows emits cp1252 (NBSP = lone byte `0xA0`), and the GitHub log viewer decodes the log as UTF-8 → one `�` per blank cell. The real symptom is a viewer that never renders any content.
2. **engineioxide polling encoder corrupts binary events** (announce + attachment fused without the `\x1e` separator when an emit lands on a parked long-poll). Reproduced deterministically on Linux, byte-level. This silently kills the viewer's connection on every affected frame and forces reconnect loops. Bug still present in latest engineioxide 0.17.3. → **Fixed by going WebSocket-only on both ends** (the broadcaster always was; the server now rejects polling with 400; regression test included).
3. **Joins can be silently dropped.** socketioxide sends the connect ack *before* running the namespace connect handler, and an `async` handler is `tokio::spawn`ed — so a `join` emitted right after the ack can be processed before `socket.on("join")` is registered, and is dropped. The Python `SocketListener` has long carried a re-emit-until-confirmed loop for exactly this; the browser viewer joined once and hoped, leaving a blank terminal for the whole test on a starved runner. → **Fixed three ways:** the connect handler is now synchronous (handlers registered inline); the viewer re-emits `join` every 500ms until the `usersCount` confirmation; the history catch-up is sent only on a socket's first join to a room so retries can't duplicate content.

## Evidence

- Parked-poll corruption, raw engine.io client (deterministic on Linux):
  ```
  451-["message",{"_placeholder":true,"num":0}]bTElWRS1GUkFNRQ0K     <- fused, unparseable
  451-["message",{"_placeholder":true,"num":0}]\x1ebTElWRS1GUkFNRQ0K <- correct framing
  ```
- A Playwright Chromium viewer pinned to polling received the corrupted bodies on every live frame and silently reconnected each time (ghost engine.io sessions inflating `usersCount`).
- The python-socketio thread deaths in CI logs (`int(b'\x1b')` — binary attachment with no pending announce) are the same desync family; the remaining suite warnings were verified by stress test to be a benign *client-side* python-socketio teardown race.
- A first Windows rerun of the transport-only fix still failed `test_late_joiner_sees_theme` (blank terminal) *and* `test_messages_isolated_to_room` ("Client 2 didn't join", a single unconfirmed join with a 15s wait) — pointing at the lost-join race as the remaining cause.

## Temporary diagnostics

The viewer page keeps a timestamped event log (`window.__rxLog`, hex dumps of received payloads) and the late-joiner test prints it - plus page console, server log tail, and CLI stderr - on failure. **To be removed once Windows CI confirms the fix** (this PR is being soaked with repeated Windows runs; target 5+ consecutive greens).

Fixes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)