### PR TITLE
test: remove dead and implementation-coupled e2e tests

### DIFF
--- a/e2e/test_api.py
+++ b/e2e/test_api.py
@@ -34,6 +34,7 @@ import re
 import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
 
+import pytest
 import websocket
 
 from conftest import (
@@ -213,75 +214,35 @@ class TestLegacyPostRetired:
     broadcasts anything to viewers.
     """
 
-    def test_post_old_style_body_returns_410(self):
-        """A well-formed old-style broadcast body should get 410 Gone."""
+    @pytest.mark.parametrize("body,extra_headers", [
+        pytest.param(
+            json.dumps({"message": "SGVsbG8sIFdvcmxkIQ==",
+                        "size": {"rows": 24, "cols": 80}}),
+            {"Authorization": "a-password"},
+            id="old-style-body",
+        ),
+        pytest.param("", {"Authorization": "a-password"}, id="empty-body"),
+        pytest.param(
+            "{ this is not valid json }",
+            {"Authorization": "a-password"},
+            id="malformed-json",
+        ),
+        pytest.param(
+            json.dumps({"message": "SGVsbG8=",
+                        "size": {"rows": 24, "cols": 80}}),
+            {},
+            id="no-authorization",
+        ),
+    ])
+    def test_post_always_returns_410(self, body, extra_headers):
+        """Any POST - well-formed, empty, malformed, unauthenticated -
+        gets the same 410 Gone with the upgrade message."""
         wait_for_server(SERVER_URL)
         room_id = f"test-{random_id()}"
-        password = f"secret-{random_id()}"
-
-        body = {
-            "message": "SGVsbG8sIFdvcmxkIQ==",
-            "size": {"rows": 24, "cols": 80}
-        }
-
-        status, headers, resp_body = make_request(
-            'POST', f'/r/{room_id}',
-            headers={"Authorization": password},
-            body=body
-        )
-
-        assert status == 410, f"Expected 410, got {status}"
-        assert resp_body == LEGACY_POST_GONE_BODY, f"Unexpected 410 body: {resp_body}"
-
-    def test_post_empty_body_returns_410(self):
-        """POST with an empty body should get 410 Gone."""
-        wait_for_server(SERVER_URL)
-        room_id = f"test-{random_id()}"
-        password = f"secret-{random_id()}"
 
         status, headers, resp_body = make_raw_request(
             'POST', f'/r/{room_id}',
-            headers={
-                "Authorization": password,
-                "Content-Type": "application/json"
-            },
-            body=""
-        )
-
-        assert status == 410, f"Expected 410, got {status}"
-        assert resp_body == LEGACY_POST_GONE_BODY, f"Unexpected 410 body: {resp_body}"
-
-    def test_post_malformed_json_returns_410(self):
-        """POST with malformed JSON should get 410 Gone, not 400."""
-        wait_for_server(SERVER_URL)
-        room_id = f"test-{random_id()}"
-        password = f"secret-{random_id()}"
-
-        status, headers, resp_body = make_raw_request(
-            'POST', f'/r/{room_id}',
-            headers={
-                "Authorization": password,
-                "Content-Type": "application/json"
-            },
-            body="{ this is not valid json }"
-        )
-
-        assert status == 410, f"Expected 410, got {status}"
-        assert resp_body == LEGACY_POST_GONE_BODY, f"Unexpected 410 body: {resp_body}"
-
-    def test_post_without_authorization_returns_410(self):
-        """POST without an Authorization header should get 410 Gone."""
-        wait_for_server(SERVER_URL)
-        room_id = f"test-{random_id()}"
-
-        body = {
-            "message": "SGVsbG8=",
-            "size": {"rows": 24, "cols": 80}
-        }
-
-        status, headers, resp_body = make_request(
-            'POST', f'/r/{room_id}',
-            headers={},  # No Authorization header
+            headers={"Content-Type": "application/json", **extra_headers},
             body=body
         )
 

--- a/e2e/test_broadcast.py
+++ b/e2e/test_broadcast.py
@@ -438,19 +438,17 @@ def test_fullscreen_mode_scales_and_restores():
         assert status == 200
         wait_for_terminal_text(page, "fullscreen test")
 
+        default_font_size = page.evaluate("window.term.options.fontSize")
+
         page.keyboard.press("f")
         page.wait_for_function(
             "document.getElementById('terminal')"
             ".classList.contains('fullscreen')",
             timeout=10000,
         )
-        # DOM contract preserved: xterm's element is the only .terminal
-        assert page.evaluate(
-            "document.querySelectorAll('#terminal .terminal').length === 1"
-        )
         # An 80x24 terminal in a larger viewport must scale up
         page.wait_for_function(
-            "window.term.options.fontSize > 14",
+            f"window.term.options.fontSize > {default_font_size}",
             timeout=10000,
         )
 
@@ -461,7 +459,7 @@ def test_fullscreen_mode_scales_and_restores():
             timeout=10000,
         )
         page.wait_for_function(
-            "window.term.options.fontSize === 14",
+            f"window.term.options.fontSize === {default_font_size}",
             timeout=10000,
         )
 

--- a/e2e/test_broadcasting_status.py
+++ b/e2e/test_broadcasting_status.py
@@ -159,14 +159,23 @@ class TestBroadcastingStatusInBrowser:
     def test_favicon_blinks_only_while_live(
         self, dedicated_server, unique_room, unique_password
     ):
-        """While the broadcaster is attached the favicon's underscore
-        cursor blinks (the page alternates between the two icon files);
-        offline it sits still on the regular icon."""
+        """While the broadcaster is attached the favicon blinks (the
+        page keeps alternating its href); offline it sits still on the
+        resting icon."""
         # Dedicated server: guarantees the freshly built binary, which
-        # is the only one that embeds the new favicon-cursor-off.png
+        # is the only one that embeds the blink's second icon frame
         server = dedicated_server()
 
         href = "document.getElementById('favicon').href"
+        install_flip_counter = (
+            "if (window.__faviconObserver) window.__faviconObserver.disconnect();"
+            "window.__faviconFlips = 0;"
+            "window.__faviconObserver ="
+            "  new MutationObserver(function () { window.__faviconFlips++; });"
+            "window.__faviconObserver"
+            ".observe(document.getElementById('favicon'),"
+            "         {attributes: true, attributeFilter: ['href']})"
+        )
 
         with sync_playwright() as p:
             browser = p.chromium.launch()
@@ -177,20 +186,15 @@ class TestBroadcastingStatusInBrowser:
                 "document.getElementById('broadcast-status').title === 'offline'",
                 timeout=10000,
             )
-            assert page.evaluate(href).endswith("/favicon.png"), \
-                "Offline room must show the static favicon"
+            resting_href = page.evaluate(href)
+            page.evaluate(install_flip_counter)
 
             ws = attach_broadcaster(unique_room, unique_password, server.url)
             try:
-                # The blink alternates, so seeing the cursor-off frame
-                # and then the cursor-on frame again proves it's cycling
+                # Two mutations prove the icon is cycling, not just
+                # switched once to a "live" icon
                 page.wait_for_function(
-                    f"{href}.endsWith('/favicon-cursor-off.png')",
-                    timeout=10000,
-                )
-                page.wait_for_function(
-                    f"{href}.endsWith('/favicon.png')",
-                    timeout=10000,
+                    "window.__faviconFlips >= 2", timeout=10000
                 )
             finally:
                 ws.close()
@@ -199,19 +203,14 @@ class TestBroadcastingStatusInBrowser:
                 "document.getElementById('broadcast-status').title === 'offline'",
                 timeout=10000,
             )
-            # Offline stops the blink and restores the regular icon; a
+            # Offline stops the blink and restores the resting icon; a
             # window longer than the blink interval with zero href
             # mutations proves it stays put (a single sample could land
-            # on the cursor-on frame of a still-running blink)
+            # on the resting frame of a still-running blink)
             page.wait_for_function(
-                f"{href}.endsWith('/favicon.png')", timeout=10000
+                f"{href} === {json.dumps(resting_href)}", timeout=10000
             )
-            page.evaluate(
-                "window.__faviconFlips = 0;"
-                "new MutationObserver(function () { window.__faviconFlips++; })"
-                ".observe(document.getElementById('favicon'),"
-                "         {attributes: true, attributeFilter: ['href']})"
-            )
+            page.evaluate(install_flip_counter)
             page.wait_for_timeout(1500)
             assert page.evaluate("window.__faviconFlips") == 0, \
                 "Favicon must stop blinking once the broadcaster detaches"

--- a/e2e/test_cli_script.py
+++ b/e2e/test_cli_script.py
@@ -9,7 +9,6 @@ actual shell spawning behavior rather than mocking.
 
 Test categories:
 - Script mode streaming
-- Terminal size handling
 - Session lifecycle
 
 Cross-platform support:
@@ -17,18 +16,13 @@ Cross-platform support:
 - Windows: Uses ConPTY (Windows 10 1809+)
 """
 
-import os
-import platform
 import subprocess
 import time
-
-import pytest
 
 from conftest import (
     CLI_COMMAND,
     SERVER_URL,
     SocketListener,
-    poll_until,
     random_id,
     wait_for_content,
 )
@@ -153,67 +147,6 @@ class TestScriptModeBasic:
         assert "Sharing terminal in" in output, "CLI should print sharing message"
         # End message is expected on clean exit, but may not appear if we had to terminate
         # This is acceptable behavior for a PTY-based implementation
-
-    def test_script_mode_delete_on_exit(self, unique_room, unique_password):
-        """DELETE should be sent when script mode exits."""
-        listener = SocketListener(unique_room)
-        listener.connect()
-
-        # Run CLI in script mode
-        run_cli_script_mode(
-            unique_room, unique_password, timeout=15
-        )
-
-        # Connect a new listener - if DELETE was sent, room should be empty
-        listener2 = SocketListener(unique_room)
-        listener2.connect()
-
-        # The exact behavior depends on server implementation
-        # (some servers clear room on DELETE, others just decrement count)
-
-        listener.disconnect()
-        listener2.disconnect()
-
-
-class TestScriptModeTerminalSize:
-    """Tests for terminal size handling in script mode."""
-
-    def test_large_terminal_warning(self, unique_room, unique_password):
-        """Large terminal should produce warning."""
-        # Create environment with large terminal
-        env = os.environ.copy()
-        env["COLUMNS"] = "200"
-        env["LINES"] = "50"
-
-        returncode, stdout, stderr = run_cli_script_mode(
-            unique_room, unique_password, env=env, timeout=15
-        )
-
-        output = stdout + stderr
-        # Check if warning about large terminal is shown
-        # (only shown if tput returns values > thresholds)
-        # This may or may not trigger depending on environment
-        # Just verify the CLI runs successfully
-        assert returncode == 0 or "Sharing terminal in" in output
-
-    def test_size_event_sent(self, unique_room, unique_password):
-        """Script mode should send terminal size to server."""
-        listener = SocketListener(unique_room)
-        listener.connect()
-
-        run_cli_script_mode(
-            unique_room, unique_password, timeout=15
-        )
-
-        # Wait for size event
-        listener.wait_for_size(timeout=5)
-
-        size = listener.get_last_size()
-        listener.disconnect()
-
-        # Size should be sent (may be None if no messages sent yet)
-        # Just verify the CLI ran and sent some output
-        assert True  # Test passes if CLI doesn't crash
 
 
 class TestScriptModeOutput:

--- a/e2e/test_cli_stdin.py
+++ b/e2e/test_cli_stdin.py
@@ -16,18 +16,13 @@ Test categories:
 import platform
 import re
 import subprocess
-import sys
-import time
 
 import pytest
 
 from conftest import (
     CLI_COMMAND,
-    CLI_PATH,
     SERVER_URL,
     SocketListener,
-    decode_message,
-    poll_until,
     random_id,
     wait_for_content,
 )
@@ -97,29 +92,6 @@ class TestBasicFunctionality:
         )
 
         assert returncode == 0
-
-    def test_sends_delete_on_exit(self, unique_room, unique_password):
-        """User count should drop after CLI exits (DELETE sent)."""
-        listener = SocketListener(unique_room)
-        listener.connect()
-
-        # Initial user count should be 1 (just the listener)
-        assert listener.wait_for_user_count(1, timeout=5)
-
-        # Run CLI - it will POST and then DELETE on exit
-        returncode, stdout, stderr = run_cli_stdin(
-            "test", unique_room, unique_password
-        )
-        assert returncode == 0
-
-        # The room data should be cleared, so a new joiner won't get the message
-        listener2 = SocketListener(unique_room)
-        listener2.connect()
-
-        # After DELETE, the room content should be cleared
-        # (This verifies DELETE was called - the exact behavior depends on server)
-        listener.disconnect()
-        listener2.disconnect()
 
 
 class TestMessageEncoding:
@@ -518,9 +490,10 @@ class TestErrorHandling:
 class TestArgumentParsing:
     """Tests for argument parsing."""
 
-    def test_version_flag(self):
-        """--version should print version and exit 0."""
-        args = CLI_COMMAND + ["--version"]
+    @pytest.mark.parametrize("flag", ["--version", "-v"])
+    def test_version_flag(self, flag):
+        """--version/-v should print version and exit 0."""
+        args = CLI_COMMAND + [flag]
 
         proc = subprocess.Popen(
             args,
@@ -536,26 +509,11 @@ class TestArgumentParsing:
         output = stdout + stderr
         assert re.search(r'\d+\.\d+\.\d+', output), f"No version found in: {output}"
 
-    def test_version_short_flag(self):
-        """-v should print version and exit 0."""
-        args = CLI_COMMAND + ["-v"]
-
-        proc = subprocess.Popen(
-            args,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
-        stdout, stderr = proc.communicate(timeout=5)
-
-        assert proc.returncode == 0
-        output = stdout + stderr
-        assert re.search(r'\d+\.\d+\.\d+', output), f"No version found in: {output}"
-
-    def test_help_flag(self):
-        """--help should print help and exit 0."""
-        args = CLI_COMMAND + ["--help"]
+    @pytest.mark.parametrize("flag", ["--help", "-h"])
+    def test_help_flag(self, flag):
+        """--help/-h should describe the CLI, its flags, and the default
+        server, then exit 0."""
+        args = CLI_COMMAND + [flag]
 
         proc = subprocess.Popen(
             args,
@@ -573,39 +531,7 @@ class TestArgumentParsing:
         assert "--room" in output or "-r" in output
         assert "--password" in output or "-W" in output
         assert "--stdin" in output
-
-    def test_help_short_flag(self):
-        """-h should print help and exit 0."""
-        args = CLI_COMMAND + ["-h"]
-
-        proc = subprocess.Popen(
-            args,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
-        stdout, stderr = proc.communicate(timeout=5)
-
-        assert proc.returncode == 0
-        output = stdout + stderr
-        # Should contain description
-        assert "shellshare" in output.lower() or "transmit" in output.lower()
-
-    def test_help_shows_default_server(self):
-        """Help should show default server URL."""
-        args = CLI_COMMAND + ["--help"]
-
-        proc = subprocess.Popen(
-            args,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
-        stdout, stderr = proc.communicate(timeout=5)
-
-        output = stdout + stderr
+        # ... and document the default server users will share through
         assert "shellshare.net" in output, "Default server URL should be in help"
 
 
@@ -657,33 +583,6 @@ class TestConcurrency:
 
         listener1.disconnect()
         listener2.disconnect()
-
-
-class TestTerminalSize:
-    """Tests for terminal size handling."""
-
-    def test_size_event_sent_with_message(self, unique_room, unique_password):
-        """Terminal size should be sent along with messages."""
-        listener = SocketListener(unique_room)
-        listener.connect()
-
-        run_cli_stdin("test", unique_room, unique_password)
-
-        # Wait for size event (sent with each POST)
-        assert listener.wait_for_size(timeout=5), "No size event received"
-
-        size = listener.get_last_size()
-
-        listener.disconnect()
-
-        # Size should have cols and rows
-        assert size is not None, "No size event received"
-        assert "cols" in size, "Size should have cols"
-        assert "rows" in size, "Size should have rows"
-        assert isinstance(size["cols"], int), "cols should be an integer"
-        assert isinstance(size["rows"], int), "rows should be an integer"
-        assert size["cols"] > 0, "cols should be positive"
-        assert size["rows"] > 0, "rows should be positive"
 
 
 class TestDefaultPassword:

--- a/e2e/test_socketio.py
+++ b/e2e/test_socketio.py
@@ -18,8 +18,6 @@ These tests are critical for ensuring the Go rewrite maintains
 identical real-time behavior.
 """
 
-import base64
-import json
 import platform
 import threading
 import time
@@ -498,57 +496,6 @@ class TestSocketIOMessageAccumulation:
 class TestSocketIOJoinEdgeCases:
     """Tests for edge cases when joining rooms."""
 
-    def test_join_without_room_prefix(self):
-        """Join with 'roomname' instead of '/r/roomname'."""
-        wait_for_server(SERVER_URL)
-
-        room_id = f"test-{random_id()}"
-        password = f"secret-{random_id()}"
-        test_message = f"NoPrefix-{random_id()}"
-
-        sio = socketio.Client()
-        received_messages = []
-        message_received = threading.Event()
-        user_count_received = threading.Event()
-
-        @sio.on('message')
-        def on_message(data):
-            received_messages.append(data)
-            message_received.set()
-
-        @sio.on('usersCount')
-        def on_users_count(count):
-            user_count_received.set()
-
-        sio.connect(SERVER_URL, transports=["websocket"])
-        # Join WITHOUT the /r/ prefix
-        sio.emit('join', room_id)
-
-        # Wait for join to complete (may or may not get usersCount depending on server behavior)
-        user_count_received.wait(timeout=2)
-
-        # Broadcast via HTTP (which uses /r/ prefix)
-        status = broadcast_message(room_id, test_message, password)
-        assert status == 200, f"Broadcast failed: {status}"
-
-        # Wait for message - might or might not be received depending on
-        # whether server strips prefix or not
-        message_received.wait(timeout=2)
-
-        # Document actual behavior
-        # The server has stripPrefix() which removes /r/ prefix
-        # So joining with "roomname" should actually work
-        if len(received_messages) > 0:
-            decoded = decode_message(received_messages[-1])
-            has_message = test_message in decoded
-        else:
-            has_message = False
-
-        # Document whether prefix is required or not
-        print(f"Join without prefix - message received: {has_message}")
-
-        sio.disconnect()
-
     def test_join_with_full_url(self):
         """Join with full URL path '/r/roomname'."""
         wait_for_server(SERVER_URL)
@@ -618,32 +565,6 @@ class TestSocketIOJoinEdgeCases:
 
         # Connection should still be alive
         assert sio.connected, "Connection dropped after joining empty room"
-
-        sio.disconnect()
-
-    def test_join_with_slashes(self):
-        """Join with room name containing slashes."""
-        wait_for_server(SERVER_URL)
-
-        room_id = f"/r/test/nested/{random_id()}"
-
-        sio = socketio.Client()
-        user_counts = []
-        count_received = threading.Event()
-
-        @sio.on('usersCount')
-        def on_users_count(count):
-            user_counts.append(count)
-            count_received.set()
-
-        sio.connect(SERVER_URL, transports=["websocket"])
-        sio.emit('join', room_id)
-
-        # Wait for user count (indicates successful join)
-        count_received.wait(timeout=2)
-
-        # Document whether nested paths work
-        print(f"Join with slashes - user counts received: {user_counts}")
 
         sio.disconnect()
 
@@ -1253,8 +1174,9 @@ class TestSocketIOEmptyRoom:
 class TestSocketIOSizePassthrough:
     """Tests for size object passthrough behavior."""
 
-    def test_size_object_exact_passthrough(self):
-        """Size object should be passed through exactly as sent."""
+    def test_size_with_extra_fields_delivers_cols_and_rows(self):
+        """Viewers get the broadcast cols/rows even when the size object
+        carries fields they don't consume."""
         wait_for_server(SERVER_URL)
 
         room_id = f"test-{random_id()}"
@@ -1293,8 +1215,10 @@ class TestSocketIOSizePassthrough:
 
         assert size_received.wait(timeout=15), "Size not received"
 
-        # Size should match exactly
-        assert sizes[-1] == custom_size, f"Expected {custom_size}, got {sizes[-1]}"
+        # The dimensions the viewer renders with must survive; whether the
+        # server forwards or drops the unknown fields is its own business
+        assert sizes[-1]["cols"] == 132, f"Expected cols=132, got {sizes[-1]}"
+        assert sizes[-1]["rows"] == 42, f"Expected rows=42, got {sizes[-1]}"
 
         sio.disconnect()
 
@@ -1424,73 +1348,6 @@ class TestSocketIOMessageFormat:
         assert idx1 < idx2 < idx3, f"Messages not in order: {idx1}, {idx2}, {idx3}"
 
         sio.disconnect()
-
-
-class TestSocketIOStripPrefix:
-    """Tests for stripPrefix behavior."""
-
-    def test_strip_prefix_removes_r_prefix(self):
-        """stripPrefix should remove /r/ prefix."""
-        wait_for_server(SERVER_URL)
-
-        room_id = f"test-{random_id()}"
-        password = f"secret-{random_id()}"
-        test_message = f"Prefix-{random_id()}"
-
-        # Two clients: one joins with prefix, one without
-        sio1 = socketio.Client()
-        sio2 = socketio.Client()
-        messages1 = []
-        messages2 = []
-        msg1_received = threading.Event()
-        msg2_received = threading.Event()
-        sio1_joined = threading.Event()
-        sio2_joined = threading.Event()
-
-        @sio1.on('message')
-        def on_msg1(data):
-            messages1.append(data)
-            msg1_received.set()
-
-        @sio1.on('usersCount')
-        def on_count1(count):
-            sio1_joined.set()
-
-        @sio2.on('message')
-        def on_msg2(data):
-            messages2.append(data)
-            msg2_received.set()
-
-        @sio2.on('usersCount')
-        def on_count2(count):
-            sio2_joined.set()
-
-        sio1.connect(SERVER_URL, transports=["websocket"])
-        sio2.connect(SERVER_URL, transports=["websocket"])
-
-        # One joins with /r/ prefix
-        sio1.emit('join', f'/r/{room_id}')
-        assert sio1_joined.wait(timeout=15), "Client 1 didn't join"
-
-        # One joins without prefix (server has /r/ as roomPrefix)
-        sio2.emit('join', f'/{room_id}')
-        sio2_joined.wait(timeout=2)  # May or may not succeed
-
-        # Broadcast
-        status = broadcast_message(room_id, test_message, password)
-        assert status == 200, f"Broadcast failed: {status}"
-
-        assert msg1_received.wait(timeout=15), "Client 1 should receive message"
-        msg2_received.wait(timeout=2)
-
-        # Client with /r/ prefix should definitely receive
-        assert len(messages1) > 0, "Client with /r/ prefix should receive message"
-
-        # Document whether client without /r/ prefix receives
-        # (depends on exact stripPrefix implementation)
-
-        sio1.disconnect()
-        sio2.disconnect()
 
 
 class TestSocketIOLargeMessage:


### PR DESCRIPTION
## Summary

Review of the e2e suite for behavior-vs-implementation coupling. Net −353 lines with no behavioral coverage lost (verified test-by-test against the rest of the suite).

**Deleted tests that could never fail:**
- `test_join_without_room_prefix` and `test_join_with_slashes` only `print()`ed the observed behavior; `test_strip_prefix_removes_r_prefix`'s one real assertion duplicated `test_join_with_full_url`
- `test_size_event_sent` ended in a literal `assert True`; `test_script_mode_delete_on_exit` and `test_sends_delete_on_exit` asserted nothing after the exit-code check — room cleanup is properly tested in `test_cli_tty.py::test_room_is_deleted_on_clean_exit`, `test_ws.py`, and the DELETE route tests

**Decoupled tests from implementation details:**
- Size passthrough now asserts viewers get the cols/rows they render with, instead of pinning the server to forwarding unknown JSON fields verbatim (the one extra field that matters, `theme`, is covered end-to-end in `test_theme.py`)
- The favicon test observes blinking via a MutationObserver (href alternates while live, sits still offline) instead of pinning asset filenames
- The fullscreen test captures the default font size dynamically instead of hardcoding 14, and drops an assertion on xterm.js's internal `.terminal` DOM class

**Consolidated near-duplicates:** four POST-410 tests → one parametrized test (wire-identical request bytes); `--version`/`-v` and `--help`/`-h` → two parametrized tests.

Also removed pre-existing unused imports from the touched files.

## Test plan

- [x] Full e2e suite: 217 passed, 2 skipped (~14s, `pytest -n 10`)
- [x] Adversarial review of the diff confirmed no lost coverage and no races in the rewritten browser tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)