### PR TITLE
style: add right margin to the users-online counter

### DIFF
--- a/public/stylesheet/room.css
+++ b/public/stylesheet/room.css
@@ -43,6 +43,7 @@
    `online` class when the broadcaster is live, and must not match */
 div.online {
   order: 1;
+  margin-right: 0.5rem;
 }
 
 .broadcast-status::before {


### PR DESCRIPTION
## Summary
Adds `margin-right: 0.5rem` to `div.online` in `public/stylesheet/room.css`, giving the "x users online" indicator in the viewer header a bit of breathing room from the right edge. Margin (not padding) since the goal is to push the whole block away from the edge, not expand its own box.

## Test plan
- [x] `make lint` clean
- [x] E2E suite: 236 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)