### PR TITLE
Make home and room pages mobile-responsive

### DIFF
--- a/public/stylesheet/base.css
+++ b/public/stylesheet/base.css
@@ -71,3 +71,15 @@ section {
   margin: 4em 0;
 }
 
+/* Phones: the desktop min-width would force horizontal panning of the
+   whole page; let the layout shrink to the viewport instead */
+@media (max-width: 47em) {
+  body {
+    min-width: 0;
+  }
+
+  section {
+    margin: 2.5em 0;
+  }
+}
+

--- a/public/stylesheet/index.css
+++ b/public/stylesheet/index.css
@@ -171,3 +171,62 @@ label[for] {
 .operating-systems input:not(:checked) + label:hover {
   color: #888;
 }
+
+/* Phones: fluid wrapper with breathing room, smaller hero title, and
+   install commands that wrap inside the pill instead of overflowing it */
+@media (max-width: 47em) {
+  .wrapper {
+    width: auto;
+    padding: 0 1em;
+  }
+
+  .title {
+    margin: 2em 0;
+  }
+
+  .title h1 {
+    /* 13vw keeps "shellshare" inside ~320px viewports */
+    font-size: clamp(2.25em, 13vw, 3em);
+  }
+
+  .title h2 {
+    font-size: 1em;
+  }
+
+  .instructions .download {
+    margin: 2em 0;
+  }
+
+  .download code {
+    padding: 1em 1.25em;
+    border-radius: 20px;
+  }
+
+  /* Long unbreakable code tokens (install commands in the pill, share
+     links and JSON events inline in the FAQ) wrap instead of widening
+     the page */
+  code {
+    overflow-wrap: anywhere;
+  }
+
+  .operating-systems {
+    text-align: center;
+    /* compensate the trailing letter-spacing after the last label,
+       which would otherwise shift the centered row left */
+    padding-left: 0.5em;
+  }
+
+  pre {
+    font-size: 0.8em;
+    /* On phones even instructional lines (e.g. the --password example)
+       fall past the clip; let them scroll instead. The scrollbar is
+       hidden so its height doesn't disturb the demo's min-height
+       measurement. */
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+
+  pre::-webkit-scrollbar {
+    display: none;
+  }
+}

--- a/public/stylesheet/room.css
+++ b/public/stylesheet/room.css
@@ -108,6 +108,22 @@ header {
   text-align: left;
 }
 
+/* Phones: pad the page chrome so it doesn't touch the screen edges.
+   #terminal stays full-bleed on purpose - every pixel of width is a
+   terminal column, and it scrolls horizontally when the broadcaster's
+   grid is wider than the viewport. */
+@media (max-width: 47em) {
+  header {
+    flex-wrap: wrap;
+    padding: 0 0.75em;
+  }
+
+  footer {
+    box-sizing: border-box;
+    padding: 0 1em;
+  }
+}
+
 .title {
   font-size: 2em;
   margin: 0;


### PR DESCRIPTION
## Summary
- Phones could not view either page without panning: `body { min-width: 748px }` forced a desktop-width layout. This lifts it under a `@media (max-width: 47em)` breakpoint and adapts the page chrome for small screens.
- **Home page**: fluid wrapper with side padding, hero title scaled via `clamp(2.25em, 13vw, 3em)`, install-command pill and inline FAQ code tokens wrap (`overflow-wrap: anywhere`), demo/FAQ `pre` blocks scroll horizontally (hidden scrollbar, so the typing demo's `min-height` measurement is undisturbed), centered OS picker.
- **Room page**: header and footer get side padding and the header can wrap. The terminal is deliberately untouched: non-fullscreen it keeps the fixed 14px font and the broadcaster's grid, staying full-bleed (every pixel is a column) and scrolling horizontally inside `#terminal` when wider than the viewport.
- Desktop is pixel-unchanged: all new rules live inside the media block; the breakpoint (47em = 752px at the UA default 16px) sits just above the old 748px min-width, so there is no gap.

## Review
Two-round subagent review: round one flagged FAQ `pre` clipping meaningful flags (e.g. `--password`) on phones plus minor nits — fixed; round two verified all fixes and found no remaining issues.

## Testing
- `make lint` passes.
- Playwright at 320/375/1280px on both pages: no document-level horizontal overflow (`scrollWidth == viewport`), screenshots inspected.
- Verified a live end-to-end-encrypted broadcast renders correctly at 375px: page stays at viewport width while wider terminal content (565px) scrolls inside the terminal box.

Note for testing locally: page CSS is inlined into the HTML **at server boot**, so restart the server after editing stylesheets (the raw `/stylesheet/*.css` routes read from disk per-request and will look fresher than the page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)