### PR TITLE
feat: attach ENV deployment label to PostHog analytics events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Environment variables read by `shellshare server`. Copy to .env and
+# adjust; all of them are optional.
+
+# Port to listen on (default: 3000)
+#PORT=3000
+
+# Usage analytics (off unless BOTH the key and the salt are set).
+# See "Analytics" in README.md for what is collected and how
+# identifiers are pseudonymized.
+#SHELLSHARE_POSTHOG_KEY=phc_yourprojectkey
+# Secret salt for pseudonymizing analytics identifiers. Keep it stable
+# across restarts and servers; rotating it resets all identities.
+#SHELLSHARE_POSTHOG_SALT=some-long-random-secret
+# PostHog ingestion host, for self-hosted PostHog (default: US cloud)
+#SHELLSHARE_POSTHOG_HOST=https://us.i.posthog.com
+
+# Deployment label (e.g. production, staging) attached to every
+# analytics event as its `environment` property, so one PostHog project
+# can tell deployments apart
+#ENV=production

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -102,8 +102,11 @@ def _server_responds(url, timeout=1):
         return False
 
 
-def _spawn_server(port, *extra_args):
+def _spawn_server(port, *extra_args, env=None):
     """Spawn a shellshare server process on the given port.
+
+    `env`, when given, fully replaces the child's environment (build it
+    from os.environ to inherit).
 
     Output goes to a log file (kept on the proc as `log_path`) so a
     startup failure - e.g. the port got taken between picking it and
@@ -126,6 +129,7 @@ def _spawn_server(port, *extra_args):
             + [str(a) for a in extra_args],
             stdout=log,
             stderr=subprocess.STDOUT,
+            env=env,
         )
     proc.log_path = Path(log_path)
     return proc
@@ -184,9 +188,9 @@ def dedicated_server():
     """
     handles = []
 
-    def start(*extra_args):
+    def start(*extra_args, env=None):
         port = _free_port()
-        proc = _spawn_server(port, *extra_args)
+        proc = _spawn_server(port, *extra_args, env=env)
         handle = ServerHandle(port=port, proc=proc)
         handles.append(handle)
         wait_for_server(handle.url, proc=proc)

--- a/e2e/test_analytics.py
+++ b/e2e/test_analytics.py
@@ -8,6 +8,7 @@ immediately after the triggering action.
 """
 
 import json
+import os
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -75,12 +76,18 @@ def mock_posthog():
     mock.shutdown()
 
 
-def analytics_server(dedicated_server, mock_posthog, *extra_args):
+def analytics_server(dedicated_server, mock_posthog, *extra_args, environment=None):
+    # ENV is scrubbed unless the test sets one, so a label in the
+    # developer's shell can't leak into the no-environment assertions
+    env = {k: v for k, v in os.environ.items() if k != "ENV"}
+    if environment is not None:
+        env["ENV"] = environment
     return dedicated_server(
         "--posthog-key", POSTHOG_KEY,
         "--posthog-host", mock_posthog.url,
         "--posthog-salt", POSTHOG_SALT,
         *extra_args,
+        env=env,
     )
 
 
@@ -133,6 +140,8 @@ def test_full_lifecycle_emits_the_three_events(dedicated_server, mock_posthog):
     for event in (created, ended, viewed):
         assert event["properties"]["$process_person_profile"] is False
         assert event["properties"]["$geoip_disable"] is True
+        # No ENV set: no environment label on any event
+        assert "environment" not in event["properties"]
         # No PII: neither the room name nor the password may appear
         # anywhere in any payload
         payload = json.dumps(event)
@@ -226,6 +235,37 @@ def test_clean_exit_emits_exactly_one_broadcast_ended(dedicated_server, mock_pos
     assert len(mock_posthog.events_named("broadcast_ended")) == 1
 
 
+def test_environment_label_is_attached_to_every_event(dedicated_server, mock_posthog):
+    server = analytics_server(dedicated_server, mock_posthog, environment="staging")
+    room = random_id()
+
+    ws = ws_connect_room(server.url, room, "pw")
+    try:
+        listener = SocketListener(room, server_url=server.url)
+        listener.connect()
+        try:
+            assert poll_until(
+                lambda: mock_posthog.events_named("viewer_joined"), timeout=10
+            ), "viewer_joined never reached the mock"
+        finally:
+            listener.disconnect()
+        ws.send(json.dumps({"delete": True}))
+    finally:
+        ws.close()
+
+    assert poll_until(
+        lambda: mock_posthog.events_named("room_created")
+        and mock_posthog.events_named("broadcast_ended"),
+        timeout=10,
+    ), "room_created/broadcast_ended never reached the mock"
+
+    with mock_posthog._lock:
+        events = list(mock_posthog.events)
+    assert events
+    for event in events:
+        assert event["properties"]["environment"] == "staging"
+
+
 def test_no_salt_disables_analytics(dedicated_server, mock_posthog):
     server = dedicated_server(
         "--posthog-key", POSTHOG_KEY,
@@ -244,7 +284,6 @@ def test_no_salt_disables_analytics(dedicated_server, mock_posthog):
 def test_serve_mode_sends_no_analytics(mock_posthog):
     # `shellshare serve` embeds the server with analytics hardcoded off;
     # the env vars that configure `shellshare server` must not leak in
-    import os
     import subprocess
 
     from conftest import CLI_COMMAND, _free_port, wait_for_server

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,6 +215,9 @@ fn start_local_server(host: &str, port: u16) -> Result<std::net::SocketAddr, Str
 /// setup beats silently degrading it (a random fallback salt would
 /// reset every identity on restart and corrupt the recurring-user
 /// metric invisibly), so each half-configured case warns and disables.
+///
+/// The deployment label comes from `ENV` (env var only, no flag): it is
+/// deployment metadata like `PORT`, not a shellshare setting.
 fn analytics_config(
     key: Option<String>,
     host: String,
@@ -225,6 +228,7 @@ fn analytics_config(
             api_key,
             host,
             salt,
+            environment: std::env::var("ENV").ok().filter(|e| !e.is_empty()),
         }),
         (Some(_), None) => {
             tracing::warn!("Analytics disabled: --posthog-key is set but --posthog-salt is not");

--- a/src/server/analytics.rs
+++ b/src/server/analytics.rs
@@ -50,6 +50,11 @@ pub struct Config {
     pub api_key: String,
     pub host: String,
     pub salt: String,
+    /// Deployment label (e.g. "production", from the `ENV` env var)
+    /// stamped on every event as the `environment` property, so one
+    /// `PostHog` project can tell deployments apart. `None` omits the
+    /// property entirely.
+    pub environment: Option<String>,
 }
 
 /// One analytics event, queued for delivery.
@@ -101,7 +106,13 @@ impl Analytics {
 
         info!("Analytics enabled, sending to {}", config.host);
         let (tx, rx) = mpsc::channel(QUEUE_CAPACITY);
-        tokio::spawn(sender_task(client, config.api_key, config.host, rx));
+        tokio::spawn(sender_task(
+            client,
+            config.api_key,
+            config.host,
+            config.environment,
+            rx,
+        ));
 
         Self {
             inner: Some(Inner {
@@ -195,6 +206,7 @@ async fn sender_task(
     client: reqwest::Client,
     api_key: String,
     host: String,
+    environment: Option<String>,
     mut rx: mpsc::Receiver<Event>,
 ) {
     let url = format!("{}/i/v0/e/", host.trim_end_matches('/'));
@@ -205,6 +217,9 @@ async fn sender_task(
         // would otherwise tag events with this server's location
         properties["$process_person_profile"] = serde_json::Value::Bool(false);
         properties["$geoip_disable"] = serde_json::Value::Bool(true);
+        if let Some(env) = &environment {
+            properties["environment"] = serde_json::Value::String(env.clone());
+        }
         let body = serde_json::json!({
             "api_key": api_key,
             "event": event.name,


### PR DESCRIPTION
## Summary

- **`ENV` deployment label on analytics events**: when the `ENV` environment variable is set (e.g. `production`, `staging`), the server stamps it on every PostHog analytics event as the `environment` property, so one PostHog project can tell deployments apart. When unset (or empty), the property is omitted entirely.
- Env var only, no CLI flag — it is deployment metadata like `PORT`, not a shellshare setting. It only takes effect when analytics are enabled (key + salt); the opt-in gate is unchanged.
- New `.env.example` at the repo root documenting all operator-facing env vars: `PORT`, `SHELLSHARE_POSTHOG_KEY`, `SHELLSHARE_POSTHOG_SALT`, `SHELLSHARE_POSTHOG_HOST`, `ENV`.
- E2E plumbing: `dedicated_server`/`_spawn_server` now accept an `env=` mapping so tests can control the spawned server's environment.

## Test coverage

- New e2e test `test_environment_label_is_attached_to_every_event`: full broadcast lifecycle with `ENV=staging`, asserts every captured event (`room_created`, `broadcast_ended`, `viewer_joined`) carries `environment: staging`.
- Existing lifecycle test now also asserts the property is **absent** when `ENV` is unset.
- The `analytics_server` helper scrubs `ENV` from the inherited environment by default, so a label in a developer's shell can't leak into the no-environment assertions.

## Test plan

- [x] `make lint` clean (pedantic clippy)
- [x] Full e2e suite green: 247 passed, 2 skipped
- [x] Analytics suite also passes with `ENV=leaked-from-shell` exported, proving the scrub works

🤖 Generated with [Claude Code](https://claude.com/claude-code)