### PR TITLE
fix: make fullscreen button reachable on touch devices

### DIFF
--- a/e2e/test_broadcast.py
+++ b/e2e/test_broadcast.py
@@ -467,6 +467,45 @@ def test_fullscreen_mode_scales_and_restores():
         browser.close()
 
 
+def test_fullscreen_button_visible_and_tappable_on_touch():
+    """
+    Touch devices have no hover to reveal the fullscreen button, so it
+    must be visible at rest (non-zero opacity) and a tap must toggle
+    fullscreen mode on and off. Emulates a Pixel-class phone.
+    """
+    room_id = f"test-{random_id()}"
+
+    wait_for_server(SERVER_URL)
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        context = browser.new_context(**p.devices["Pixel 7"])
+        page = context.new_page()
+        page.goto(f"{SERVER_URL}/r/{room_id}")
+        page.wait_for_selector("#fullscreen-toggle", timeout=10000)
+
+        opacity = page.locator("#fullscreen-toggle").evaluate(
+            "el => parseFloat(getComputedStyle(el).opacity)"
+        )
+        assert opacity > 0, f"button invisible on touch device: opacity={opacity}"
+
+        page.locator("#fullscreen-toggle").tap()
+        page.wait_for_function(
+            "document.getElementById('terminal')"
+            ".classList.contains('fullscreen')",
+            timeout=10000,
+        )
+
+        page.locator("#fullscreen-toggle").tap()
+        page.wait_for_function(
+            "!document.getElementById('terminal')"
+            ".classList.contains('fullscreen')",
+            timeout=10000,
+        )
+
+        browser.close()
+
+
 if __name__ == "__main__":
     test_happy_path_broadcast_appears_in_browser()
     test_user_counter_shows_in_browser()
@@ -476,3 +515,4 @@ if __name__ == "__main__":
     test_unicode_renders_in_browser()
     test_resize_updates_browser_terminal()
     test_fullscreen_mode_scales_and_restores()
+    test_fullscreen_button_visible_and_tappable_on_touch()

--- a/public/stylesheet/room.css
+++ b/public/stylesheet/room.css
@@ -158,9 +158,9 @@ header {
   top: 8px;
   right: 8px;
   z-index: 2;
-  width: 32px;
-  height: 32px;
-  padding: 6px;
+  width: 44px;
+  height: 44px;
+  padding: 11px;
   border: 0;
   border-radius: 4px;
   background: rgba(0, 0, 0, 0.45);
@@ -173,6 +173,14 @@ header {
 #terminal:hover #fullscreen-toggle,
 #fullscreen-toggle:focus-visible {
   opacity: 1;
+}
+
+/* Touch devices have no hover to reveal the button: keep it visible
+   at rest */
+@media (hover: none) {
+  #fullscreen-toggle {
+    opacity: 0.5;
+  }
 }
 
 /* While fullscreen the button must stay reachable: touch devices have


### PR DESCRIPTION
## Problem

On mobile (reported on Pixel 9 / Brave), tapping the viewer's fullscreen button did nothing.

Root cause: the button is hidden (`opacity: 0`) and only revealed by `#terminal:hover`. Touch devices have no hover, so the button was invisible at rest and taps landed on the terminal canvas instead.

## Fix

- Reveal the button at rest on `(hover: none)` devices (`opacity: 0.5`).
- Bump the button to 44px so it's a proper finger-sized touch target on mobile, while staying balanced on desktop (verified via screenshot; it still fades in on hover there).

## Tests

Added `test_fullscreen_button_visible_and_tappable_on_touch` (Pixel 7 emulation) — fails without the fix, passes with it. Full e2e suite green (250 passed, 2 skipped), lint clean.

Verified under touch emulation, not real Brave on a Pixel, so worth a tap on the actual device once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)