### PR TITLE
feat: give viewer_joined an anonymous per-join identity

### DIFF
--- a/e2e/test_analytics.py
+++ b/e2e/test_analytics.py
@@ -126,16 +126,17 @@ def test_full_lifecycle_emits_the_three_events(dedicated_server, mock_posthog):
     ended = mock_posthog.events_named("broadcast_ended")[0]
     viewed = mock_posthog.events_named("viewer_joined")[0]
 
-    # The broadcaster identity is stable across events and prefixed,
-    # the room identity is the plaintext room name in its own id space
+    # Broadcast events share the stable bc: identity (a machine running
+    # the CLI); the viewer join is an anonymous per-join id, never the
+    # broadcaster. Every event carries the plaintext room name, which is
+    # what ties the viewer join back to the broadcast events.
     assert started["distinct_id"].startswith("bc:")
     assert ended["distinct_id"] == started["distinct_id"]
-    assert viewed["distinct_id"] == f"room:{room}"
-
-    # Broadcast events carry the room id, so they join with viewer
-    # events (whose distinct_id IS the room)
-    assert started["properties"]["room"] == viewed["distinct_id"]
-    assert ended["properties"]["room"] == viewed["distinct_id"]
+    assert viewed["distinct_id"].startswith("viewer:")
+    assert viewed["distinct_id"] != started["distinct_id"]
+    assert started["properties"]["room"] == room
+    assert ended["properties"]["room"] == room
+    assert viewed["properties"]["room"] == room
     # This segment claimed the room - a fresh share, not a reconnect
     assert started["properties"]["new_room"] is True
 
@@ -230,7 +231,7 @@ def test_abrupt_disconnect_emits_one_broadcast_ended(dedicated_server, mock_post
     first, second = mock_posthog.events_named("broadcast_started")
     assert first["properties"]["new_room"] is True
     assert second["properties"]["new_room"] is False
-    assert first["properties"]["room"] == f"room:{room}"
+    assert first["properties"]["room"] == room
     assert second["properties"]["room"] == first["properties"]["room"]
     assert second["distinct_id"] == first["distinct_id"]
 

--- a/src/server/analytics.rs
+++ b/src/server/analytics.rs
@@ -14,12 +14,15 @@
 //!   password)`: the default client password is MAC-derived, so the
 //!   HMAC is stable per machine (recurring-user detection) while the
 //!   secret salt keeps the small MAC space safe from enumeration and
-//!   keeps custom passwords uncrackable from the analytics data. Room
-//!   names, by contrast, are sent in plaintext - they are share-link
-//!   slugs, visible to anyone with the link, and readable dashboards
-//!   beat hiding them. Broadcast events carry the room id as a
-//!   property, linking a broadcaster to its rooms so the operator can
-//!   join broadcast metrics to viewer metrics.
+//!   keeps custom passwords uncrackable from the analytics data. That
+//!   `bc:` identity is the distinct id of every broadcast event, so a
+//!   "person" in `PostHog` is a machine running the CLI. Viewers send
+//!   no credentials and have no server-side identity, so `viewer_joined`
+//!   gets a throwaway random distinct id per join - an anonymous viewer,
+//!   never conflated with the broadcaster. Room names ride along as a
+//!   plain `room` property on every event: they are share-link slugs,
+//!   visible to anyone with the link, readable dashboards beat hiding
+//!   them, and they tie viewer joins back to the broadcast events.
 //! - **Stateless server**: the salt is operator-supplied, not generated,
 //!   so identities survive restarts and server moves (reuse the salt).
 //!
@@ -136,7 +139,7 @@ impl Analytics {
                 name: "broadcast_started",
                 distinct_id: inner.broadcaster_id(password),
                 properties: serde_json::json!({
-                    "room": Inner::room_id(room_name),
+                    "room": room_name,
                     "new_room": new_room,
                 }),
             });
@@ -153,7 +156,7 @@ impl Analytics {
                 name: "broadcast_ended",
                 distinct_id: inner.broadcaster_id(password),
                 properties: serde_json::json!({
-                    "room": Inner::room_id(room_name),
+                    "room": room_name,
                     // Fractional: short segments would otherwise all
                     // truncate to 0 and undercount reconnect-heavy runs
                     "duration_seconds": duration.as_secs_f64(),
@@ -164,15 +167,20 @@ impl Analytics {
 
     /// A viewer joined an existing room - live (`broadcasting`) or a
     /// replay of one whose broadcaster dropped but wasn't evicted yet.
-    /// Viewers send no credentials, so the identity is the room's, not
-    /// the viewer's: this measures rooms that got an audience and how
-    /// big it was, not unique viewers.
+    /// Viewers send no credentials and have no server-side identity, so
+    /// each join gets a throwaway random distinct id: the event honestly
+    /// represents an anonymous viewer (not the broadcaster), and the
+    /// `room` property still ties it back to the broadcast events. This
+    /// measures which rooms drew an audience and how big it was (via
+    /// `user_count`), not unique viewers - the id deliberately carries
+    /// no information to dedupe on.
     pub fn viewer_joined(&self, room_name: &str, user_count: usize, broadcasting: bool) {
         if let Some(inner) = &self.inner {
             inner.send(Event {
                 name: "viewer_joined",
-                distinct_id: Inner::room_id(room_name),
+                distinct_id: format!("viewer:{:032x}", rand::random::<u128>()),
                 properties: serde_json::json!({
+                    "room": room_name,
                     "user_count": user_count,
                     "broadcasting": broadcasting,
                 }),
@@ -189,18 +197,10 @@ impl Inner {
         }
     }
 
-    /// Stable pseudonymous broadcaster identity. The `bc:` prefix keeps
-    /// this id space disjoint from room-derived ids.
+    /// Stable pseudonymous broadcaster identity - the distinct id of
+    /// every event. The `bc:` prefix marks the id as a broadcaster's.
     fn broadcaster_id(&self, password: &str) -> String {
         format!("bc:{}", hmac_hex(&self.salt, password))
-    }
-
-    /// Room identity: the distinct id of viewer events and the `room`
-    /// property of broadcast events, so the two sides join on it.
-    /// Plaintext by choice (see the module doc); the `room:` prefix
-    /// keeps this id space disjoint from broadcaster ids.
-    fn room_id(room_name: &str) -> String {
-        format!("room:{room_name}")
     }
 }
 


### PR DESCRIPTION
## What

`viewer_joined`'s PostHog `distinct_id` was the room (`room:<name>`), which split persons into two id spaces and made room names the "people" in the dashboard. This makes the identities honest:

- **Broadcast events** (`broadcast_started` / `broadcast_ended`) keep the stable pseudonymous `bc:` identity — a "person" is a machine running the CLI.
- **`viewer_joined`** now gets a throwaway random `viewer:<hex>` id per join. Viewers send no credentials and have no server-side identity, so the id deliberately carries nothing to dedupe on — it just means "an anonymous viewer," never conflated with the broadcaster.
- The **`room` property** is on every event, which is what ties a viewer join back to its broadcast events. The `room:` prefix is gone since rooms are no longer a distinct-id space.

## Why per-join anonymous (not the broadcaster's `bc:`)

The `room` property already links audience to broadcaster on every event, so attributing viewer joins to the broadcaster bought only a no-join "distinct broadcasters with an audience" count — at the cost of polluting the broadcaster's person with their audience's activity. Real unique/returning viewers would need a persistent per-viewer id (client-side UUID), which is out of scope here; a hashed IP was rejected as still-PII, brute-forceable, and inaccurate behind NAT.

What you can still answer: which rooms drew an audience and how big (`user_count`), and which broadcaster via the `room` join.

## Testing

`make lint` clean; full e2e suite green (249 passed, 2 skipped). `e2e/test_analytics.py` updated to assert broadcast events share the `bc:` id while the viewer join is a distinct `viewer:`-prefixed id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)