### PR TITLE
fix: give the fullscreen toggle z-index headroom over xterm

### DIFF
--- a/public/stylesheet/room.css
+++ b/public/stylesheet/room.css
@@ -163,8 +163,9 @@ header {
      the hit-test for a tap landing on the button. A bare z-index: 2 tied
      the link layer, so which one received the tap was render-order
      dependent - it worked under one renderer and silently failed under
-     another (e.g. the canvas fallback on GPU-less CI). */
-  z-index: 6;
+     another (e.g. the canvas fallback on GPU-less CI). Parked far above
+     anything xterm uses so a future layer can't quietly tie it again. */
+  z-index: 9999;
   width: 44px;
   height: 44px;
   padding: 11px;


### PR DESCRIPTION
## Summary

Follow-up to #147. That PR raised the viewer's fullscreen toggle to `z-index: 6` to clear xterm's pointer-capturing overlays (the `.xterm-link-layer` canvas at `z-index: 2` and the helper textarea at `z-index: 5`). It works, but leaves only a one-step margin over the textarea — a future xterm version that adds or bumps a layer could quietly tie or pass `6` and silently steal the tap again (the same render-order-dependent bug #147 fixed, just one upgrade away).

This parks the toggle at `z-index: 9999`, far above anything xterm uses, so it stays the hit-test winner without us having to track xterm's internal z-index values.

## Why a number, not a test

We considered adding an e2e regression test asserting the toggle out-stacks every pointer-capturing xterm layer. With a deliberately huge z-index, such a test would essentially only ever fire if someone lowered the toggle's *own* z-index in a refactor — xterm's layers live in the single digits and won't climb into the thousands. We opted for the self-evidently-robust value instead.

## Testing

- `make lint` clean.
- Original bug was reproduced and the fix verified on a real Android device (Pixel 9 Pro, Brave) via remote debugging: with the old tie, `elementFromPoint` over the button returned the link-layer canvas and taps did nothing; with the bump, the button is the hit-test target and touch toggles fullscreen both ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)