### PR TITLE
test: widen CLI-session subprocess timeouts to survive CI CPU starvation

### DIFF
--- a/e2e/test_agents.py
+++ b/e2e/test_agents.py
@@ -26,6 +26,18 @@ from conftest import (
 
 IS_WINDOWS = platform.system() == "Windows"
 
+# Spawning the CLI and waiting for it to broadcast, then drain and shut
+# down its session, is normally ~60ms. But these subprocess timeouts are
+# WALL-CLOCK, and the suite runs `-n 10` on shared CI runners: under heavy
+# CPU oversubscription every thread-scheduling point and bounded sleep in
+# the CLI's shutdown path stretches out. Measured serial worst cases under
+# ~5x CPU oversubscription reached ~8s, with a tail that grows with load,
+# and the Python test process itself can be descheduled against its own
+# timeout. A generous wall-clock budget keeps these green under that
+# scheduling pressure without masking a genuine hang (a real hang never
+# returns at all). The median run is unaffected.
+CLI_SESSION_TIMEOUT = 60
+
 
 def parse_json_events(stdout):
     """Parse the shellshare events out of stdout. Exec mode interleaves the
@@ -56,7 +68,7 @@ class TestJsonContract:
             input="hello agents\n",
             capture_output=True,
             text=True,
-            timeout=15,
+            timeout=CLI_SESSION_TIMEOUT,
         )
         assert proc.returncode == 0
 
@@ -80,7 +92,7 @@ class TestJsonContract:
             input="hi\n",
             capture_output=True,
             text=True,
-            timeout=15,
+            timeout=CLI_SESSION_TIMEOUT,
         )
         assert "Sharing terminal in" not in proc.stdout + proc.stderr
         assert "End of transmission" not in proc.stdout + proc.stderr
@@ -101,7 +113,7 @@ class TestExecSubcommand:
                 + ["--", "echo", marker],
                 capture_output=True,
                 text=True,
-                timeout=20,
+                timeout=CLI_SESSION_TIMEOUT,
                 stdin=subprocess.DEVNULL,
             )
             assert proc.returncode == 0
@@ -129,7 +141,7 @@ class TestExecSubcommand:
             + ["--", "sh", "-c", "exit 3"],
             capture_output=True,
             text=True,
-            timeout=20,
+            timeout=CLI_SESSION_TIMEOUT,
             stdin=subprocess.DEVNULL,
         )
         assert proc.returncode == 3

--- a/e2e/test_cli_serve.py
+++ b/e2e/test_cli_serve.py
@@ -65,11 +65,17 @@ def start_serve(port, room, password, host=None):
     )
 
 
-def finish(proc, message="", timeout=15):
+def finish(proc, message="", timeout=30):
     """Send the message, close stdin and wait for the CLI to exit.
 
     Kills the process on timeout so a hung CLI doesn't leak and hold its
     port for the rest of the (parallel) test run.
+
+    `timeout` is wall-clock and generous: `serve` boots an embedded
+    server and runs a full client session, normally a second or two, but
+    under `-n 10` on an oversubscribed CI runner thread scheduling and the
+    CLI's bounded shutdown sleeps stretch out. The kill-on-timeout above
+    still bounds a genuine hang.
     """
     try:
         stdout, stderr = proc.communicate(input=message, timeout=timeout)

--- a/e2e/test_cli_stdin.py
+++ b/e2e/test_cli_stdin.py
@@ -29,11 +29,19 @@ from conftest import (
 )
 
 
-def run_cli_stdin(message, room, password, server=SERVER_URL, extra_args=None, timeout=10):
+def run_cli_stdin(message, room, password, server=SERVER_URL, extra_args=None, timeout=30):
     """
     Run the CLI in stdin mode with the given message.
 
     Returns (returncode, stdout, stderr)
+
+    `timeout` is wall-clock and generous on purpose: a full CLI session
+    (connect, broadcast, drain, shut down) is normally well under a
+    second, but under `-n 10` on an oversubscribed CI runner the CLI's
+    bounded shutdown sleeps and thread scheduling stretch out - measured
+    serial worst cases reached several seconds. The slack absorbs that
+    scheduling pressure without masking a genuine hang (which never
+    returns at all).
     """
     args = CLI_COMMAND + ["--stdin", "-s", server, "-r", room, "-W", password]
     if extra_args:

--- a/e2e/test_encryption.py
+++ b/e2e/test_encryption.py
@@ -41,10 +41,15 @@ def parse_share_url(text):
     return match.group(1) if match else None
 
 
-def run_cli(message, room, password, timeout=10, encrypt=True):
+def run_cli(message, room, password, timeout=30, encrypt=True):
     """Run the CLI in stdin mode until EOF.
 
     Returns (returncode, stderr, share_url).
+
+    `timeout` is wall-clock and deliberately generous: a full CLI session
+    is normally sub-second, but under `-n 10` on an oversubscribed CI
+    runner the CLI's bounded shutdown sleeps and thread scheduling stretch
+    to several seconds. The slack absorbs that without hiding a real hang.
     """
     args = CLI_COMMAND + ["--stdin", "-s", SERVER_URL, "-r", room, "-W", password]
     if not encrypt:

--- a/e2e/test_theme.py
+++ b/e2e/test_theme.py
@@ -29,8 +29,14 @@ SOLARIZED_LIGHT_BG = "rgb(253, 246, 227)"
 TANGO_BG = "rgb(18, 19, 20)"  # the default theme
 
 
-def run_cli_stdin(message, room, password, server=SERVER_URL, extra_args=None, timeout=10):
-    """Run the CLI in stdin mode. Returns (returncode, stdout, stderr)."""
+def run_cli_stdin(message, room, password, server=SERVER_URL, extra_args=None, timeout=30):
+    """Run the CLI in stdin mode. Returns (returncode, stdout, stderr).
+
+    `timeout` is wall-clock and generous: a full CLI session is normally
+    sub-second, but under `-n 10` on an oversubscribed CI runner the CLI's
+    bounded shutdown sleeps and thread scheduling stretch to several
+    seconds. The slack absorbs that without masking a genuine hang.
+    """
     args = CLI_COMMAND + ["--stdin", "-s", server, "-r", room, "-W", password]
     if extra_args:
         args.extend(extra_args)


### PR DESCRIPTION
## Problem

`test_exec_propagates_exit_code` intermittently failed in CI with `subprocess.TimeoutExpired` after 20s (seen during PRs #146/#147). It usually passes, but under `-n 10` parallel load the `shellshare exec` subprocess occasionally didn't return in time.

## Root cause (environmental, not a hang or race)

A full CLI session — connect, broadcast, drain, shut down — is normally **~60ms**. But these `subprocess(..., timeout=N)` budgets are **wall-clock**, and the suite runs `-n 10` on shared CI runners. Driving the release binary directly under ~5× CPU oversubscription:

- No contention: `exec -- sh -c 'exit 3'` finishes in ~0.06s (50/50).
- Under oversubscription: the same call regularly took **3–8s**, with a load-dependent tail; the Python test process also gets descheduled against its own timeout.
- **No invocation ever failed to return** — confirming there's no deadlock; the CLI's bounded shutdown sleeps and thread scheduling simply stretch under starvation.

So on an already-saturated CI runner the tail occasionally crossed the 20s budget.

## Fix

Raise the wall-clock budgets with explanatory comments — they are safety nets, not performance assertions (a genuine hang never returns and is still caught; the median run is unaffected):

- `test_agents.py`: a single `CLI_SESSION_TIMEOUT = 60` (was 15/20).
- `test_cli_stdin.py`, `test_encryption.py`, `test_theme.py`: stdin-session helper default 10 → 30.
- `test_cli_serve.py`: `finish()` default 15 → 30 (already kills-on-timeout, so a real hang stays bounded).

Legitimate fire-and-forget **settle windows** (e.g. analytics absence assertions in `test_analytics.py`) were deliberately left untouched.

## Verification

- Previously-flaky exec test: **30× serial under CPU burn** and **25× at `-n 16` under burn** — all green.
- Full suite **3× at `-n 16` under CPU burn**, plus `-n 10` clean: **250 passed, 2 skipped** every run.

Investigated this via a subagent; the diagnosis was reproduced by stress-driving the binary directly (not just by re-running until green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)