### PR TITLE
Make the mobile room viewer landscape-first

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ e2e/multiroom-*.json
 # Misc
 ecosystem.json5
 e2e/loadgen/target/
+
+# Visual companion (brainstorming) scratch
+/.superpowers/

--- a/docs/superpowers/specs/2026-06-13-mobile-viewer-design.md
+++ b/docs/superpowers/specs/2026-06-13-mobile-viewer-design.md
@@ -1,0 +1,174 @@
+# Mobile room-viewer design
+
+**Date:** 2026-06-13
+**Status:** Approved design, ready for implementation plan
+**Scope:** `templates/room.html` (viewer script) and `public/stylesheet/room.css`. No
+server or CLI changes.
+
+## Problem
+
+The room viewer (`/r/:room`) is built around a fixed-grid terminal: the broadcaster's
+`cols × rows` (typically 80 × 24) is authoritative and the page renders it with xterm.js.
+On a portrait phone this creates a poor default experience, verified on a Pixel 9 (Chrome
+and Brave, ~426 CSS-px wide) against a live broadcast over `adb reverse`:
+
+1. **Horizontal clipping (core issue).** The default, non-fullscreen view renders 80 cols
+   at the 14px base font ≈ 670px wide on a ~426px screen. The right ~25 columns are cut
+   off and the viewer must scroll sideways to read full lines.
+2. **Wasted vertical space.** That view pins the 24-row terminal to the top third of the
+   screen with a large empty gap below; portrait height goes unused.
+3. **Fullscreen portrait is unreadable.** The existing fullscreen font-fit *does* fit all
+   80 cols, but only by shrinking the font to ~5px.
+4. **Landscape fullscreen is genuinely good** — readable font, full width, full height —
+   but it is gated behind two non-obvious manual steps: physically rotate the device *and*
+   find the corner fullscreen toggle (50% opacity on touch).
+5. **Browser + page chrome** (address bar, header, footer) consume scarce portrait height.
+
+**There is no rendering or encryption bug on mobile.** Early blank-screen observations
+during investigation were test-harness artifacts (a dropped `adb reverse` tunnel,
+broadcasters exiting, and room TTL eviction). With a live broadcaster and the tunnel up,
+both plaintext and encrypted rooms render crisply on the device.
+
+The product already contains a good mobile experience (landscape-fullscreen). The design
+goal is to make that the **obvious default** instead of something the viewer must discover.
+
+## Direction
+
+**Lean into landscape** (lowest-risk): treat landscape-fullscreen as the intended mobile
+viewing mode and guide viewers into it, rather than re-engineering portrait terminal
+rendering. Explicitly **out of scope**: pinch-to-zoom/pan, CSS content-rotation,
+follow-the-cursor auto-pan, header/footer copy redesign.
+
+## Platform constraints (the reason the design looks the way it does)
+
+- Browsers **cannot** enter fullscreen or lock orientation on page load; both require a
+  user gesture. "Automatic immersive" is therefore impossible — entry must be one tap.
+- `screen.orientation.lock('landscape')` works on **Android Chrome** (only while
+  fullscreen) but is **unsupported on iOS Safari**, which also has no element Fullscreen
+  API. The viewer already ships a class-based fill-the-page fullscreen fallback for iOS;
+  this design builds on it.
+
+## Detection
+
+Touch devices get the new behavior, gated on `window.matchMedia('(pointer: coarse)')`.
+Fine-pointer (mouse/keyboard) devices — including touch laptops — keep today's behavior
+unchanged: hover-reveal corner toggle, `f` to toggle fullscreen, native size, horizontal
+scroll. The detection is re-evaluated on `fullscreenchange` and `resize` so a device that
+never matches simply never shows the affordance.
+
+## Behavior
+
+### 1. Portrait landing — fit-to-width live preview + overlay (Variant A)
+
+When a coarse-pointer device is **not** in fullscreen:
+
+- **Fit-to-width preview.** The font auto-fits so all `cols` fit the viewport *width*
+  (no horizontal scroll). This is a new branch of the existing `fitTerminal()` logic,
+  which today scales only in fullscreen and otherwise pins `BASE_FONT_PX`. The not-
+  fullscreen coarse-pointer branch fits to width only (height is allowed to overflow /
+  scroll vertically), reusing the same proportional-scale + integer-px + overflow-nudge
+  convergence the fullscreen path already uses, clamped at `MIN_FONT_PX`.
+- **Full-terminal overlay.** A single tap target covering the terminal, layered above
+  xterm's pointer-capturing overlays (the same z-index lesson as the corner toggle —
+  park it far above xterm's internal layers). Contents, centered:
+  - the expand icon (reuse the existing `.icon-expand` SVG),
+  - label **"Tap to watch fullscreen"**,
+  - sub-hint **"↻ rotates to landscape for readable text"**.
+- The overlay is a real focusable control (`role="button"`, `aria-label`, keyboard
+  activatable) for accessibility, even though touch is the primary path.
+- The corner fullscreen toggle is **hidden** in this state; the overlay is the entry point.
+- **Offline/idle broadcaster:** the overlay label is unchanged ("Tap to watch fullscreen")
+  — one code path regardless of broadcaster state. The existing broadcast-status dot and
+  user count continue to convey live/offline.
+
+### 2. The tap → immersive
+
+On activation, within the user-gesture handler, in order:
+
+1. Enter fullscreen: native `requestFullscreen()` / `webkitRequestFullscreen()` where
+   available, else add the `fullscreen` class (existing iOS fallback). This reuses the
+   current `enterFullscreen()`.
+2. Attempt `screen.orientation.lock('landscape')`; `.catch()` is a silent no-op (iOS,
+   older Android, permission failure).
+3. The existing fullscreen font-fit (`fitTerminal()` in its current fullscreen branch)
+   produces the readable landscape view.
+
+### 3. Rotate nudge (fallback for un-lockable platforms)
+
+While in fullscreen **and** the orientation is still portrait (iOS, or Android where the
+lock did not take), show a small dismissible-on-rotate nudge **"Rotate your phone ↻"**.
+Driven by `@media (orientation: portrait)` scoped to the fullscreen state, so it auto-hides
+the instant the device reports landscape. No JS polling of orientation required for the
+hide; it is CSS-driven.
+
+### 4. Exit
+
+Exit via the OS back gesture, `Esc`, or the corner compress icon (shown while immersive,
+as today). On exit:
+
+- `screen.orientation.unlock()` (no-op where unsupported).
+- Remove the `fullscreen` class (existing `exitFullscreen()` / `onFullscreenChange()`).
+- The portrait preview + overlay return.
+
+The existing `onFullscreenChange()` remains the single source of truth so OS/browser-driven
+exits (swipe-down, Esc, browser UI) stay in sync; orientation unlock and overlay
+restoration hang off the same path.
+
+### 5. Screen Wake Lock (should-have, in scope)
+
+On entering immersive, request `navigator.wakeLock.request('screen')` so the screen does
+not sleep during a live broadcast. Release on exit. Re-acquire on `visibilitychange` when
+the page returns to visible and is still immersive (wake locks are auto-released when a tab
+is hidden). All calls guarded for absence of the API and wrapped so a rejection is a silent
+no-op.
+
+### 6. Desktop
+
+Unchanged. None of the above triggers under a fine pointer.
+
+## Affected code & boundaries
+
+- `templates/room.html` (inline viewer script):
+  - New: coarse-pointer detection helper; overlay element + activation handler; orientation
+    lock/unlock; wake-lock acquire/release; fit-to-width-when-not-fullscreen branch in the
+    fit logic.
+  - Reused unchanged: WebSocket transport, decryption, theme, history replay, the
+    `enterFullscreen`/`exitFullscreen`/`onFullscreenChange`/`fitTerminal` skeleton.
+  - The overlay markup lives in the static template alongside `#fullscreen-toggle`;
+    visibility is class/media-driven.
+- `public/stylesheet/room.css`:
+  - New: overlay styling, rotate-nudge (orientation media query within fullscreen),
+    coarse-pointer/portrait visibility rules, hiding the corner toggle in the preview state.
+  - The existing fullscreen layout block and `(hover: none)` toggle rules stay; the overlay
+    rules sit beside them.
+
+These are additive: the desktop and existing fullscreen paths keep their current structure,
+and the new behavior is gated behind media queries and the coarse-pointer check.
+
+## Testing
+
+E2E is the source of truth (no Rust unit tests, per project convention). Add Playwright
+coverage using mobile device emulation (portrait viewport + `hasTouch`):
+
+- Portrait preview fits to width (no horizontal overflow; font < base).
+- The tap-to-watch overlay is present and is the active tap target on a coarse-pointer
+  viewport, and absent on a desktop viewport.
+- Activating the overlay adds the `fullscreen` class and triggers the fullscreen font-fit
+  (native fullscreen + orientation lock are not assertable headless; assert the class-based
+  fallback path and that lock is *attempted* — e.g. via a stub/now-throws-caught).
+- Rotate-nudge visibility flips with the emulated orientation while fullscreen.
+- Existing desktop viewer tests stay green (regression guard for the unchanged path).
+
+Manual on-device verification on the Pixel 9 over `adb reverse` during implementation:
+real native fullscreen, real `orientation.lock`, real wake lock, and the portrait→tap→
+landscape flow end to end.
+
+## Risks & mitigations
+
+- **`orientation.lock` rejects without fullscreen / on unsupported platforms** → always
+  `.catch()` to no-op; the rotate nudge covers the un-lockable case.
+- **Overlay losing the hit-test to xterm's layers** → place it above xterm's internal
+  z-indexes (the `#147`/`#148` lesson), and e2e-assert it receives the tap.
+- **Fit-to-width changing layout for unexpected viewports** → gate strictly on
+  `(pointer: coarse)` and re-evaluate on resize; desktop path untouched.
+- **Wake lock auto-released on tab hide** → re-acquire on `visibilitychange`.

--- a/e2e/test_broadcast.py
+++ b/e2e/test_broadcast.py
@@ -467,11 +467,13 @@ def test_fullscreen_mode_scales_and_restores():
         browser.close()
 
 
-def test_fullscreen_button_visible_and_tappable_on_touch():
+def test_touch_overlay_enters_immersive_and_toggle_exits():
     """
-    Touch devices have no hover to reveal the fullscreen button, so it
-    must be visible at rest (non-zero opacity) and a tap must toggle
-    fullscreen mode on and off. Emulates a Pixel-class phone.
+    On touch devices the immersive overlay - not the corner toggle - is
+    the entry point. Out of fullscreen the overlay is visible and the
+    corner toggle is hidden; tapping the overlay enters fullscreen, where
+    the corner toggle returns (now the way out) and the overlay hides.
+    Emulates a Pixel-class phone.
     """
     room_id = f"test-{random_id()}"
 
@@ -482,26 +484,127 @@ def test_fullscreen_button_visible_and_tappable_on_touch():
         context = browser.new_context(**p.devices["Pixel 7"])
         page = context.new_page()
         page.goto(f"{SERVER_URL}/r/{room_id}")
-        page.wait_for_selector("#fullscreen-toggle", timeout=10000)
+        page.wait_for_selector("#immersive-overlay", timeout=10000)
 
-        opacity = page.locator("#fullscreen-toggle").evaluate(
-            "el => parseFloat(getComputedStyle(el).opacity)"
+        # Out of fullscreen on touch: overlay shown, corner toggle hidden.
+        overlay_shown = page.locator("#immersive-overlay").evaluate(
+            "el => getComputedStyle(el).display !== 'none' && "
+            "parseFloat(getComputedStyle(el).opacity) > 0"
         )
-        assert opacity > 0, f"button invisible on touch device: opacity={opacity}"
+        assert overlay_shown, "immersive overlay not shown on touch device"
+        toggle_display = page.locator("#fullscreen-toggle").evaluate(
+            "el => getComputedStyle(el).display"
+        )
+        assert toggle_display == "none", \
+            f"corner toggle should be hidden out of fullscreen, got {toggle_display}"
 
-        page.locator("#fullscreen-toggle").tap()
+        # Tap the overlay -> enters fullscreen.
+        page.locator("#immersive-overlay").tap()
         page.wait_for_function(
             "document.getElementById('terminal')"
             ".classList.contains('fullscreen')",
             timeout=10000,
         )
+        # Inside fullscreen: corner toggle returns, overlay hides.
+        page.wait_for_function(
+            "getComputedStyle(document.getElementById('fullscreen-toggle'))"
+            ".display !== 'none'",
+            timeout=10000,
+        )
+        page.wait_for_function(
+            "getComputedStyle(document.getElementById('immersive-overlay'))"
+            ".display === 'none'",
+            timeout=10000,
+        )
 
+        # Tap the corner toggle -> exits fullscreen.
         page.locator("#fullscreen-toggle").tap()
         page.wait_for_function(
             "!document.getElementById('terminal')"
             ".classList.contains('fullscreen')",
             timeout=10000,
         )
+
+        browser.close()
+
+
+def test_touch_portrait_fits_terminal_to_width():
+    """
+    On a portrait touch device the font is scaled down so all of the
+    broadcaster's columns fit the viewport width - a readable-overview
+    preview, smaller than the desktop base font and with no horizontal
+    overflow. (Desktop keeps the base font; see the fullscreen test.)
+    """
+    room_id = f"test-{random_id()}"
+    password = f"secret-{random_id()}"
+    key = os.urandom(32).hex()
+
+    wait_for_server(SERVER_URL)
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        context = browser.new_context(**p.devices["Pixel 7"])
+        page = context.new_page()
+        page.goto(f"{SERVER_URL}/r/{room_id}#{key}")
+        page.wait_for_selector("#terminal", timeout=10000)
+        page.wait_for_function(
+            "document.getElementById('online-counter').textContent !== '0'",
+            timeout=10000,
+        )
+
+        status = broadcast_message(
+            SERVER_URL, room_id, password, "fit to width test",
+            size={"cols": 80, "rows": 24}, key=key,
+        )
+        assert status == 200
+        wait_for_terminal_text(page, "fit to width test")
+
+        # 80 cols at the 14px base would overflow a ~412px phone; the
+        # preview shrinks the font below the base to fit the width.
+        page.wait_for_function(
+            "window.term && window.term.options.fontSize < 14",
+            timeout=10000,
+        )
+        no_overflow = page.evaluate(
+            "(function () {"
+            "  var s = window.term.element.querySelector('.xterm-screen');"
+            "  var c = document.getElementById('terminal');"
+            "  return s.getBoundingClientRect().width <= c.clientWidth + 1;"
+            "})()"
+        )
+        assert no_overflow, "terminal grid overflows viewport width on touch"
+
+        browser.close()
+
+
+def test_immersive_overlay_hidden_on_desktop():
+    """
+    The immersive overlay is touch-only. A desktop (fine-pointer) viewer
+    never sees it and keeps the hover-revealed corner toggle as the
+    fullscreen entry point.
+    """
+    room_id = f"test-{random_id()}"
+
+    wait_for_server(SERVER_URL)
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()  # default desktop context: fine pointer
+        page.goto(f"{SERVER_URL}/r/{room_id}")
+        # Hidden on desktop, so wait for it in the DOM, not for visibility.
+        page.wait_for_selector("#immersive-overlay", state="attached", timeout=10000)
+
+        overlay_display = page.locator("#immersive-overlay").evaluate(
+            "el => getComputedStyle(el).display"
+        )
+        assert overlay_display == "none", \
+            f"overlay should be hidden on desktop, got display={overlay_display}"
+
+        toggle_display = page.locator("#fullscreen-toggle").evaluate(
+            "el => getComputedStyle(el).display"
+        )
+        assert toggle_display != "none", \
+            "corner toggle should remain the desktop entry point"
 
         browser.close()
 
@@ -515,4 +618,6 @@ if __name__ == "__main__":
     test_unicode_renders_in_browser()
     test_resize_updates_browser_terminal()
     test_fullscreen_mode_scales_and_restores()
-    test_fullscreen_button_visible_and_tappable_on_touch()
+    test_touch_overlay_enters_immersive_and_toggle_exits()
+    test_touch_portrait_fits_terminal_to_width()
+    test_immersive_overlay_hidden_on_desktop()

--- a/public/stylesheet/room.css
+++ b/public/stylesheet/room.css
@@ -243,3 +243,94 @@ header {
      then eats on every pass */
   padding: 0;
 }
+
+/* Immersive entry affordance for touch devices. Out of fullscreen, the
+   whole terminal becomes one tap target with a centered prompt: the
+   viewer sees a small fit-to-width preview (all columns visible, set by
+   the viewer script) and taps to enter the readable landscape view. On
+   touch this REPLACES the corner toggle as the entry point; the toggle
+   returns inside fullscreen as the way out. Hidden on fine-pointer
+   (desktop) devices, where hover + the corner toggle already work. */
+#immersive-overlay {
+  display: none;
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 1rem;
+  border: 0;
+  background: linear-gradient(rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0.55));
+  color: rgba(255, 255, 255, 0.95);
+  font-family: 'Open Sans', sans-serif;
+  text-align: center;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+#immersive-overlay .io-icon {
+  box-sizing: border-box;
+  width: 64px;
+  height: 64px;
+  padding: 14px;
+  border: 2px solid rgba(255, 255, 255, 0.85);
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+#immersive-overlay .io-label {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+#immersive-overlay .io-sub {
+  margin-top: -0.4rem;
+  font-size: 0.8rem;
+  opacity: 0.8;
+}
+
+/* Rotate nudge: the honest fallback when we can't lock orientation
+   (iOS, or Android where the lock was refused). Shown only while
+   fullscreen AND the device is still portrait, so it disappears the
+   instant the viewer rotates - no JS polling needed. */
+#rotate-nudge {
+  display: none;
+  position: fixed;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 101;
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  font-family: 'Open Sans', sans-serif;
+  font-size: 0.85rem;
+  padding: 0.5em 0.9em;
+  border-radius: 999px;
+}
+
+@media (pointer: coarse) {
+  #terminal:not(.fullscreen) #immersive-overlay {
+    display: flex;
+  }
+
+  #terminal:not(.fullscreen) #fullscreen-toggle {
+    display: none;
+  }
+}
+
+@media (pointer: coarse) and (orientation: portrait) {
+  #terminal.fullscreen #rotate-nudge {
+    display: block;
+  }
+}
+
+/* A blocked encrypted broadcast shows its explanatory notice instead;
+   don't cover it with the tap-to-watch prompt. */
+#terminal.crypto-blocked #immersive-overlay {
+  display: none;
+}

--- a/templates/room.html
+++ b/templates/room.html
@@ -606,16 +606,34 @@
       // visibilitychange while still immersive. Absent API or rejection
       // is a silent no-op.
       var wakeLock = null;
+      // A request is asynchronous, and the native-fullscreen path calls
+      // acquire twice in quick succession (enterFullscreen, then the
+      // fullscreenchange handler) before the first resolves. Without a
+      // pending guard both fire request('screen') and the second sentinel
+      // orphans the first, which then leaks. The flag collapses concurrent
+      // requests to one.
+      var wakeLockPending = false;
       function acquireWakeLock() {
-        if (wakeLock || !navigator.wakeLock) {
+        if (wakeLock || wakeLockPending || !navigator.wakeLock) {
           return;
         }
+        wakeLockPending = true;
         navigator.wakeLock.request('screen').then(function (lock) {
+          wakeLockPending = false;
+          // If we left immersive mode while the request was in flight,
+          // drop this lock instead of holding one releaseWakeLock has
+          // already missed.
+          if (!isFullscreen()) {
+            lock.release().catch(function () {});
+            return;
+          }
           wakeLock = lock;
           lock.addEventListener('release', function () {
             wakeLock = null;
           });
-        }).catch(function () {});
+        }).catch(function () {
+          wakeLockPending = false;
+        });
       }
 
       function releaseWakeLock() {

--- a/templates/room.html
+++ b/templates/room.html
@@ -40,6 +40,16 @@
             <path d="M8 3v3a2 2 0 0 1-2 2H3M21 8h-3a2 2 0 0 1-2-2V3M3 16h3a2 2 0 0 1 2 2v3M16 21v-3a2 2 0 0 1 2-2h3"/>
           </svg>
         </button>
+        <button id="immersive-overlay" type="button" aria-label="Watch fullscreen in landscape">
+          <svg class="io-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M8 3H5a2 2 0 0 0-2 2v3M16 3h3a2 2 0 0 1 2 2v3M8 21H5a2 2 0 0 1-2-2v-3M16 21h3a2 2 0 0 0 2-2v-3"/>
+          </svg>
+          <span class="io-label">Tap to watch fullscreen</span>
+          <span class="io-sub">&#x21bb; rotates to landscape for readable text</span>
+        </button>
+        <div id="rotate-nudge" role="status" aria-hidden="true">
+          <span class="rn-icon">&#x21bb;</span> Rotate your phone for readable text
+        </div>
       </div>
     </main>
     <footer>
@@ -94,6 +104,7 @@
         document.getElementById('broadcast-status-text');
       var terminalContainer = document.getElementById('terminal');
       var fullscreenToggle = document.getElementById('fullscreen-toggle');
+      var immersiveOverlay = document.getElementById('immersive-overlay');
       var favicon = document.getElementById('favicon');
       var cryptoNotice = document.getElementById('crypto-notice');
 
@@ -564,6 +575,69 @@
                document.webkitFullscreenElement || null;
       }
 
+      // Lock to landscape on entering immersive mode. Supported on
+      // Android Chrome (only while fullscreen); a no-op everywhere it
+      // isn't (notably iOS Safari, which has no orientation lock and no
+      // element Fullscreen API - the fill-the-page class fallback plus
+      // the CSS rotate nudge cover it there). Any rejection is silent.
+      function lockLandscape() {
+        try {
+          var o = window.screen && window.screen.orientation;
+          if (o && o.lock) {
+            var p = o.lock('landscape');
+            if (p && p.catch) {
+              p.catch(function () {});
+            }
+          }
+        } catch (e) {}
+      }
+
+      function unlockOrientation() {
+        try {
+          var o = window.screen && window.screen.orientation;
+          if (o && o.unlock) {
+            o.unlock();
+          }
+        } catch (e) {}
+      }
+
+      // Keep the screen awake while watching a live broadcast. The lock
+      // is auto-released when the tab is hidden, so it is re-acquired on
+      // visibilitychange while still immersive. Absent API or rejection
+      // is a silent no-op.
+      var wakeLock = null;
+      function acquireWakeLock() {
+        if (wakeLock || !navigator.wakeLock) {
+          return;
+        }
+        navigator.wakeLock.request('screen').then(function (lock) {
+          wakeLock = lock;
+          lock.addEventListener('release', function () {
+            wakeLock = null;
+          });
+        }).catch(function () {});
+      }
+
+      function releaseWakeLock() {
+        if (wakeLock) {
+          wakeLock.release().catch(function () {});
+          wakeLock = null;
+        }
+      }
+
+      // Idempotent: both the class fallback (enterFullscreen, no native
+      // event on iOS) and the native fullscreenchange handler call these,
+      // and a re-entrant call must not double-lock or leak a wake lock.
+      function enterImmersive() {
+        lockLandscape();
+        acquireWakeLock();
+      }
+
+      function exitImmersive() {
+        unlockOrientation();
+        releaseWakeLock();
+      }
+
       function enterFullscreen() {
         terminalContainer.classList.add('fullscreen');
         var rfs = terminalContainer.requestFullscreen ||
@@ -575,6 +649,11 @@
             result.catch(function () {});
           }
         }
+        // Runs inside the tap/keypress gesture, which orientation lock
+        // requires. Native fullscreen also re-runs it from
+        // onFullscreenChange; the class fallback (iOS) has no such event,
+        // so this call is what covers it there.
+        enterImmersive();
         fitTerminal();
       }
 
@@ -587,6 +666,7 @@
           }
         }
         terminalContainer.classList.remove('fullscreen');
+        exitImmersive();
         fitTerminal();
       }
 
@@ -620,17 +700,40 @@
         return screen ? screen.getBoundingClientRect() : null;
       }
 
+      function overflowsWidth(rect) {
+        return rect.width > terminalContainer.clientWidth;
+      }
+
       function overflows(rect) {
-        return rect.width > terminalContainer.clientWidth ||
+        return overflowsWidth(rect) ||
                rect.height > terminalContainer.clientHeight;
       }
 
+      // Touch devices (phones, tablets). Mouse/keyboard devices - even
+      // ones with a touchscreen - keep a fine pointer and the desktop
+      // behavior. Drives both the fit-to-width preview here and, in
+      // room.css, the immersive overlay and rotate nudge.
+      function isCoarsePointer() {
+        return !!(window.matchMedia &&
+                  window.matchMedia('(pointer: coarse)').matches);
+      }
+
+      // Two scaling regimes share one convergence loop:
+      // - Fullscreen: fit the grid to both axes (fill the screen).
+      // - Touch, not fullscreen: fit to WIDTH only, so all the
+      //   broadcaster's columns are visible without horizontal scroll.
+      //   The result is a small but complete "preview" the viewer taps
+      //   to enter the readable landscape view; height is free to grow
+      //   and scroll. A fine-pointer page out of fullscreen keeps the
+      //   base font (desktop is unchanged).
       function fitTerminal() {
         if (!term || !term.element) {
           return;
         }
         var token = ++fitToken;
-        if (!isFullscreen()) {
+        var fs = isFullscreen();
+        var fitWidthOnly = !fs && isCoarsePointer();
+        if (!fs && !fitWidthOnly) {
           setFontSize(BASE_FONT_PX);
           return;
         }
@@ -640,18 +743,22 @@
         if (!rect || !rect.width || !rect.height) {
           return;
         }
-        var scale = Math.min(terminalContainer.clientWidth / rect.width,
-                             terminalContainer.clientHeight / rect.height);
+        var scaleW = terminalContainer.clientWidth / rect.width;
+        var scale = fs ?
+          Math.min(scaleW, terminalContainer.clientHeight / rect.height) :
+          scaleW;
         // Integer px keeps glyphs crisp
         setFontSize(Math.max(MIN_FONT_PX,
                              Math.floor(term.options.fontSize * scale)));
         requestAnimationFrame(function nudge() {
-          if (token !== fitToken || !isFullscreen()) {
+          var stillFs = isFullscreen();
+          var stillFitWidth = !stillFs && isCoarsePointer();
+          if (token !== fitToken || (!stillFs && !stillFitWidth)) {
             return;
           }
           var rect = screenRect();
-          if (rect && overflows(rect) &&
-              term.options.fontSize > MIN_FONT_PX) {
+          var over = stillFs ? overflows(rect) : overflowsWidth(rect);
+          if (rect && over && term.options.fontSize > MIN_FONT_PX) {
             setFontSize(term.options.fontSize - 1);
             requestAnimationFrame(nudge);
           }
@@ -675,13 +782,29 @@
       // fallback path never fires this event, so its class handling
       // is untouched.
       function onFullscreenChange() {
-        terminalContainer.classList.toggle('fullscreen',
-                                           !!nativeFullscreenElement());
+        var entering = !!nativeFullscreenElement();
+        terminalContainer.classList.toggle('fullscreen', entering);
+        if (entering) {
+          enterImmersive();
+        } else {
+          exitImmersive();
+        }
         scheduleFit();
       }
 
       fullscreenToggle.addEventListener('click', toggleFullscreen);
+      // On touch the overlay - not the corner toggle - is the entry
+      // point (room.css hides the toggle and shows the overlay there).
+      // It only ever shows out of fullscreen, so enter, don't toggle.
+      immersiveOverlay.addEventListener('click', enterFullscreen);
       window.addEventListener('resize', scheduleFit);
+      // The wake lock is dropped when the tab is hidden; take it back on
+      // return if still watching immersively.
+      document.addEventListener('visibilitychange', function () {
+        if (document.visibilityState === 'visible' && isFullscreen()) {
+          acquireWakeLock();
+        }
+      });
       document.addEventListener('fullscreenchange', onFullscreenChange);
       document.addEventListener('webkitfullscreenchange', onFullscreenChange);
       document.addEventListener('keydown', function (e) {


### PR DESCRIPTION
## Problem

On a portrait phone the room viewer rendered the broadcaster's 80-col grid at the 14px base font (~670px wide on a ~412px screen), so the right ~25 columns were **clipped behind a horizontal scroll** — you watched a stream you couldn't fully read. Tapping fullscreen fit all 80 cols, but only by shrinking the font to ~5px (unreadable). Landscape-fullscreen was already genuinely good — readable, full-width, full-height — but it was gated behind two non-obvious steps: physically rotate the device **and** find the 50%-opacity corner toggle.

The good mobile experience already existed; it was just hidden. This PR makes it the default.

## Approach — lean into landscape

Touch devices (`matchMedia('(pointer: coarse)')`) now get:

- **Fit-to-width live preview** — a new not-fullscreen branch of the existing font-fit loop scales the font so *all* columns fit the width (no side-scroll). The portrait landing is a small but complete preview of the session.
- **Full-terminal "Tap to watch fullscreen" overlay** as the entry point (centered expand icon + label + "↻ rotates to landscape" hint). The corner toggle is hidden out of fullscreen and returns *inside* fullscreen as the way out.
- **One tap → fullscreen + `screen.orientation.lock('landscape')`** on Android Chrome. The lock is a silent no-op everywhere it isn't supported.
- **CSS-driven rotate nudge** while fullscreen-and-portrait — the honest fallback for iOS Safari (no Fullscreen/lock API) and lock-refused Android. Auto-hides the instant the device reports landscape.
- **Screen Wake Lock** while immersive, re-acquired on `visibilitychange` (wake locks drop when a tab is hidden).

**Desktop (fine pointer) is unchanged** — hover-revealed corner toggle and `f` key as before. No server or CLI changes; this is `templates/room.html` + `public/stylesheet/room.css` only.

## Testing

- New Playwright **mobile-emulation** e2e tests (Pixel 7 context): overlay is the touch entry point and the corner toggle is the exit; portrait fits the grid to width with no overflow; the overlay is absent on desktop. Updated the prior touch test to the new overlay flow.
- Full e2e suite green (252 passed, 2 pre-existing skips).
- **Verified end-to-end on a real Pixel 9** over `adb`: portrait preview + overlay → one tap → auto-rotated readable landscape → exit returns cleanly to the portrait preview. Confirmed there is **no** mobile rendering/encryption bug (both plaintext and encrypted rooms render crisply).

Design rationale: `docs/superpowers/specs/2026-06-13-mobile-viewer-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)