### PR TITLE
fix: make the landscape touch overlay fit the whole session

### DIFF
--- a/e2e/test_broadcast.py
+++ b/e2e/test_broadcast.py
@@ -577,6 +577,77 @@ def test_touch_portrait_fits_terminal_to_width():
         browser.close()
 
 
+def test_touch_landscape_fits_whole_grid_and_overlay():
+    """
+    On a landscape touch device the whole grid fits BOTH axes (no vertical
+    scroll), unlike the width-only portrait preview, and the immersive
+    overlay sits inside the viewport - not floating in an over-tall scroll
+    height. The "rotate to landscape" hint is dropped (already landscape).
+    Regression guard for the landscape overlay rendering as a stray icon.
+    """
+    room_id = f"test-{random_id()}"
+    password = f"secret-{random_id()}"
+    key = os.urandom(32).hex()
+
+    wait_for_server(SERVER_URL)
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        # Pixel 7 rotated to landscape: width > height flips the
+        # orientation media query and gives the grid a wide box to fill.
+        device = dict(p.devices["Pixel 7"])
+        vp = device["viewport"]
+        device["viewport"] = {"width": vp["height"], "height": vp["width"]}
+        context = browser.new_context(**device)
+        page = context.new_page()
+        page.goto(f"{SERVER_URL}/r/{room_id}#{key}")
+        page.wait_for_selector("#terminal", timeout=10000)
+        page.wait_for_function(
+            "document.getElementById('online-counter').textContent !== '0'",
+            timeout=10000,
+        )
+
+        status = broadcast_message(
+            SERVER_URL, room_id, password, "landscape fit test",
+            size={"cols": 80, "rows": 24}, key=key,
+        )
+        assert status == 200
+        wait_for_terminal_text(page, "landscape fit test")
+
+        # Both axes fit: the grid is no taller than its viewport-bounded
+        # box (a width-only fit of 24 rows would overflow this height).
+        page.wait_for_function(
+            "(function () {"
+            "  var s = window.term.element.querySelector('.xterm-screen');"
+            "  var c = document.getElementById('terminal');"
+            "  var r = s.getBoundingClientRect();"
+            "  return r.height <= c.clientHeight + 1 &&"
+            "         r.width <= c.clientWidth + 1;"
+            "})()",
+            timeout=10000,
+        )
+
+        # The overlay covers the visible area, not an off-screen mid-scroll
+        # band: its box stays within the viewport.
+        overlay_in_view = page.evaluate(
+            "(function () {"
+            "  var r = document.getElementById('immersive-overlay')"
+            "    .getBoundingClientRect();"
+            "  return r.top >= -1 && r.bottom <= window.innerHeight + 1;"
+            "})()"
+        )
+        assert overlay_in_view, "immersive overlay floats outside the viewport"
+
+        # The rotate hint is meaningless in landscape, so it's hidden.
+        sub_display = page.locator("#immersive-overlay .io-sub").evaluate(
+            "el => getComputedStyle(el).display"
+        )
+        assert sub_display == "none", \
+            f"'rotate to landscape' hint should be hidden in landscape, got {sub_display}"
+
+        browser.close()
+
+
 def test_immersive_overlay_hidden_on_desktop():
     """
     The immersive overlay is touch-only. A desktop (fine-pointer) viewer
@@ -620,4 +691,5 @@ if __name__ == "__main__":
     test_fullscreen_mode_scales_and_restores()
     test_touch_overlay_enters_immersive_and_toggle_exits()
     test_touch_portrait_fits_terminal_to_width()
+    test_touch_landscape_fits_whole_grid_and_overlay()
     test_immersive_overlay_hidden_on_desktop()

--- a/public/stylesheet/room.css
+++ b/public/stylesheet/room.css
@@ -329,6 +329,15 @@ header {
   }
 }
 
+/* Already landscape: the preview fits the whole grid on screen (viewer
+   script) and the "rotate to landscape" hint no longer applies, so drop
+   it and leave just the tap-to-watch label. */
+@media (pointer: coarse) and (orientation: landscape) {
+  #immersive-overlay .io-sub {
+    display: none;
+  }
+}
+
 /* A blocked encrypted broadcast shows its explanatory notice instead;
    don't cover it with the tap-to-watch prompt. */
 #terminal.crypto-blocked #immersive-overlay {

--- a/templates/room.html
+++ b/templates/room.html
@@ -736,25 +736,61 @@
                   window.matchMedia('(pointer: coarse)').matches);
       }
 
-      // Two scaling regimes share one convergence loop:
+      // Phone held in landscape. The not-fullscreen preview fits the
+      // whole grid on screen here (see fitTerminal), and the immersive
+      // overlay drops its "rotate to landscape" hint (room.css) - there's
+      // nothing left to rotate.
+      function isLandscape() {
+        return !!(window.matchMedia &&
+                  window.matchMedia('(orientation: landscape)').matches);
+      }
+
+      // Height available to a viewport-pinned preview: everything below
+      // the terminal's top edge. offsetTop is a layout offset (scroll
+      // independent), so this stays stable as the live tail scrolls.
+      function previewHeight() {
+        return Math.max(0, window.innerHeight - terminalContainer.offsetTop);
+      }
+
+      // Three scaling regimes share one convergence loop:
       // - Fullscreen: fit the grid to both axes (fill the screen).
-      // - Touch, not fullscreen: fit to WIDTH only, so all the
-      //   broadcaster's columns are visible without horizontal scroll.
-      //   The result is a small but complete "preview" the viewer taps
-      //   to enter the readable landscape view; height is free to grow
-      //   and scroll. A fine-pointer page out of fullscreen keeps the
-      //   base font (desktop is unchanged).
+      // - Touch + portrait, not fullscreen: fit to WIDTH only, so every
+      //   column shows without horizontal scroll. Height is free to grow
+      //   and scroll - a small but complete "preview" the viewer taps to
+      //   enter the readable landscape view.
+      // - Touch + landscape, not fullscreen: the grid already has a wide
+      //   aspect to fill, so fit BOTH axes into a viewport-bounded box.
+      //   The whole session shows at once with no scroll, and the
+      //   immersive overlay (inset:0 of that box) covers exactly the
+      //   visible area instead of floating in an over-tall scroll height.
+      // A fine-pointer page out of fullscreen keeps the base font
+      // (desktop is unchanged).
       function fitTerminal() {
         if (!term || !term.element) {
           return;
         }
         var token = ++fitToken;
         var fs = isFullscreen();
-        var fitWidthOnly = !fs && isCoarsePointer();
-        if (!fs && !fitWidthOnly) {
+        var preview = !fs && isCoarsePointer();
+        // Pin the landscape preview to the viewport so both axes have a
+        // bounded box to fit into; every other regime lets height follow
+        // content (fullscreen fills the CSS-fixed box). border-box so the
+        // height includes #terminal's padding - otherwise the padding
+        // pushes the box (and the overlay covering it) past the viewport.
+        if (preview && isLandscape()) {
+          terminalContainer.style.boxSizing = 'border-box';
+          terminalContainer.style.height = previewHeight() + 'px';
+        } else {
+          terminalContainer.style.boxSizing = '';
+          terminalContainer.style.height = '';
+        }
+        if (!fs && !preview) {
           setFontSize(BASE_FONT_PX);
           return;
         }
+        // Fullscreen and the landscape preview fit both axes; portrait
+        // fits width only.
+        var fitBoth = fs || isLandscape();
         // Cell dimensions are near-linear in font size, so the ratio
         // at the current size gives the target directly
         var rect = screenRect();
@@ -762,7 +798,7 @@
           return;
         }
         var scaleW = terminalContainer.clientWidth / rect.width;
-        var scale = fs ?
+        var scale = fitBoth ?
           Math.min(scaleW, terminalContainer.clientHeight / rect.height) :
           scaleW;
         // Integer px keeps glyphs crisp
@@ -770,12 +806,13 @@
                              Math.floor(term.options.fontSize * scale)));
         requestAnimationFrame(function nudge() {
           var stillFs = isFullscreen();
-          var stillFitWidth = !stillFs && isCoarsePointer();
-          if (token !== fitToken || (!stillFs && !stillFitWidth)) {
+          var stillPreview = !stillFs && isCoarsePointer();
+          if (token !== fitToken || (!stillFs && !stillPreview)) {
             return;
           }
+          var stillBoth = stillFs || isLandscape();
           var rect = screenRect();
-          var over = stillFs ? overflows(rect) : overflowsWidth(rect);
+          var over = stillBoth ? overflows(rect) : overflowsWidth(rect);
           if (rect && over && term.options.fontSize > MIN_FONT_PX) {
             setFontSize(term.options.fontSize - 1);
             requestAnimationFrame(nudge);


### PR DESCRIPTION
## Problem

On a landscape phone the not-fullscreen preview fit the broadcaster's grid **to width only**, so 80 columns across the wide screen pushed the rows ~1.5× taller than the viewport. The `#immersive-overlay` ("Tap to watch fullscreen") is `inset: 0` of that over-tall `#terminal`, so its centered icon + label sat at the vertical middle of the whole scroll height — off-screen. With the live tail pinned to the bottom, all the viewer saw was an **orphaned icon floating in the terminal text**, and the "↻ rotates to landscape" sub-line was wrong when already in landscape.

## Fix

Landscape touch viewers now:

- fit the grid to **both axes** into a viewport-bounded box (`box-sizing: border-box` height, so `#terminal`'s 5px padding can't push the box — and the overlay covering it — past the fold). The whole session shows at once with no vertical scroll, and the overlay covers exactly the visible area.
- drop the "rotate to landscape" hint, leaving just the tap-to-watch label.

Portrait keeps its fit-to-width preview (with the rotate hint); fullscreen and desktop are unchanged.

## Testing

- Verified on a Pixel 9 over adb: landscape overlay renders as a clean centered card, tap → fullscreen works, portrait unchanged.
- New e2e test `test_touch_landscape_fits_whole_grid_and_overlay` (Pixel 7 rotated to landscape) asserts the grid fits both axes, the overlay stays inside the viewport, and the hint is hidden. It caught a 10px padding overflow before the `border-box` fix.
- `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)