### PR TITLE
Make the viewer page chrome follow the broadcast theme

### DIFF
--- a/e2e/test_theme.py
+++ b/e2e/test_theme.py
@@ -60,6 +60,27 @@ def terminal_background(page):
     )
 
 
+def page_background(page):
+    """The page body's computed background color - the chrome around the
+    terminal, which the viewer tints to match the theme."""
+    return page.evaluate(
+        "getComputedStyle(document.body).backgroundColor"
+    )
+
+
+def parse_rgb(value):
+    """('rgb(r, g, b)' as served by getComputedStyle) -> (r, g, b)."""
+    match = re.match(r"rgb\((\d+),\s*(\d+),\s*(\d+)\)", value)
+    assert match, f"unexpected color value: {value!r}"
+    return tuple(int(c) for c in match.groups())
+
+
+def perceived_luminance(rgb):
+    """sRGB perceived brightness in 0..1 - mirrors the viewer script."""
+    r, g, b = rgb
+    return (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255
+
+
 class TestThemeWireFormat:
     """The theme must ride inside the size event, verbatim."""
 
@@ -178,6 +199,61 @@ class TestThemeRendering:
 
                 wait_for_terminal_text(page, "themed output")
                 assert terminal_background(page) == expected_bg
+                browser.close()
+        finally:
+            proc.stdin.close()
+            proc.wait(timeout=10)
+
+    @pytest.mark.parametrize("theme_args, light", [
+        (["--theme", "solarized-light"], True),
+        ([], False),  # the default theme (tango) is dark
+    ], ids=["light", "default-dark"])
+    def test_page_chrome_follows_theme(self, dedicated_server, theme_args, light):
+        """The page chrome (body background) tracks the theme so a light
+        terminal doesn't sit on a dark page or a dark one on white, yet is
+        offset from the terminal so the terminal still reads as a distinct
+        surface. Driven client-side from the theme in the size message."""
+        server = dedicated_server()
+        room_id = f"chrome-{random_id()}"
+        password = f"secret-{random_id()}"
+
+        proc = subprocess.Popen(
+            CLI_COMMAND + [
+                "--stdin", "-s", server.url, "-r", room_id, "-W", password,
+            ] + theme_args,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            share_url = None
+            for line in proc.stderr:
+                match = SHARE_LINK_RE.search(line)
+                if match:
+                    share_url = match.group(1)
+                    break
+            assert share_url, "No share link in CLI output"
+
+            with sync_playwright() as p:
+                browser = p.chromium.launch()
+                page = browser.new_page()
+                page.goto(share_url)
+                page.wait_for_selector("#terminal", timeout=10000)
+
+                proc.stdin.write("chrome output\n")
+                proc.stdin.flush()
+
+                wait_for_terminal_text(page, "chrome output")
+                page_bg = parse_rgb(page_background(page))
+                term_bg = parse_rgb(terminal_background(page))
+                # Tracks the theme's tone...
+                if light:
+                    assert perceived_luminance(page_bg) > 0.6
+                else:
+                    assert perceived_luminance(page_bg) < 0.4
+                # ...but is offset so the terminal isn't lost in the page
+                assert page_bg != term_bg
                 browser.close()
         finally:
             proc.stdin.close()

--- a/public/stylesheet/room.css
+++ b/public/stylesheet/room.css
@@ -39,6 +39,56 @@
   font-display: swap;
 }
 
+/* Page chrome follows the broadcast terminal's theme so a dark terminal
+   never sits on a blinding white page (and a light theme like
+   solarized-light gets a light page). The viewer script derives these
+   custom properties from the theme's own background/foreground and sets
+   them on <html>; the fallbacks here are the chrome the script computes
+   for the default theme (tango), so the page already looks right before
+   the first size message lands - no flash, even for the common case of a
+   broadcast that took the default theme. The theme can't be known server
+   side: this page is rendered once and shared across every room, and the
+   theme only arrives later over the WebSocket.
+   Scoped to the room page (this stylesheet) - the home page is untouched. */
+html {
+  background-color: var(--page-bg, #222324);
+}
+
+body {
+  background-color: var(--page-bg, #222324);
+  color: var(--page-fg, #cccccc);
+}
+
+/* Animate only live theme changes (the broadcaster re-themes mid-session),
+   not the first paint - the initial apply must land instantly so there's
+   no fade from the pre-size default into the real theme. */
+body.theme-transitions {
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+/* The fallbacks below are tango's accent (bright blue) and muted tone,
+   matching the script's output for the default theme - see above. */
+a,
+a:visited {
+  color: var(--page-accent, #729fcf);
+}
+
+a:hover {
+  color: var(--page-muted, #787979);
+}
+
+.title a,
+.title a:hover,
+.title a:visited {
+  color: var(--page-fg, #cccccc);
+}
+
+footer,
+footer a,
+footer a:visited {
+  color: var(--page-muted, #787979);
+}
+
 /* div.online, not .online: the broadcast-status span also carries an
    `online` class when the broadcaster is live, and must not match */
 div.online {

--- a/templates/room.html
+++ b/templates/room.html
@@ -560,7 +560,91 @@
         // The container peeks out around the canvas (padding, short
         // pages); keep it matched to the terminal background
         terminalContainer.style.backgroundColor = colors.background;
+        applyPageChrome(colors, entry);
       }
+
+      // Drive the page chrome (body/header/footer/links) from the
+      // terminal theme so a dark terminal never blinds the viewer on a
+      // white page, and a light theme gets a light page. The values ride
+      // as CSS custom properties on <html> (see room.css); deciding
+      // dark-vs-light from the background's luminance only picks the link
+      // accent (a palette blue) and keeps text legible against it.
+      function parseHex(hex) {
+        if (typeof hex !== 'string' || !/^#[0-9a-fA-F]{6}$/.test(hex)) {
+          return null;
+        }
+        return [
+          parseInt(hex.substr(1, 2), 16),
+          parseInt(hex.substr(3, 2), 16),
+          parseInt(hex.substr(5, 2), 16),
+        ];
+      }
+
+      function toHex(rgb) {
+        return '#' + rgb.map(function (c) {
+          var h = Math.round(Math.max(0, Math.min(255, c))).toString(16);
+          return h.length === 1 ? '0' + h : h;
+        }).join('');
+      }
+
+      // Perceived brightness (0-1) of an sRGB color
+      function luminance(rgb) {
+        return (0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2]) / 255;
+      }
+
+      // Blend two colors; t=0 returns a, t=1 returns b
+      function mix(a, b, t) {
+        return [
+          a[0] + (b[0] - a[0]) * t,
+          a[1] + (b[1] - a[1]) * t,
+          a[2] + (b[2] - a[2]) * t,
+        ];
+      }
+
+      function applyPageChrome(colors, entry) {
+        // No real theme yet (pre-size default, or an unknown name): leave
+        // the page at the CSS default (dark) rather than forcing it black,
+        // so there's no flash before the broadcaster's theme lands.
+        if (!entry) {
+          return;
+        }
+        var bg = parseHex(colors.background) || [18, 19, 20];
+        var fg = parseHex(colors.foreground) || [204, 204, 204];
+        var lum = luminance(bg);
+        var dark = lum < 0.5;
+        // Offset the page background from the terminal so the terminal
+        // reads as a distinct surface instead of bleeding into the page.
+        // Normally the page goes a bit darker (the terminal "floats"
+        // above it); a near-black terminal can't go darker, so lift the
+        // page instead. toHex clamps, so the shift never wraps.
+        var SHIFT = 16;
+        var dir = lum < 0.12 ? 1 : -1;
+        var pageBg = toHex([
+          bg[0] + dir * SHIFT, bg[1] + dir * SHIFT, bg[2] + dir * SHIFT,
+        ]);
+        // Muted text (footer, link hover): foreground faded toward the
+        // background, staying readable on either tone
+        var muted = toHex(mix(fg, bg, 0.45));
+        // Link accent: the theme's own blue (bright blue on dark themes
+        // for contrast, plain blue on light), falling back to foreground
+        var palette = entry.palette;
+        var accent = (palette && palette[dark ? 12 : 4]) || colors.foreground;
+        var root = document.documentElement.style;
+        root.setProperty('--page-bg', pageBg);
+        root.setProperty('--page-fg', colors.foreground);
+        root.setProperty('--page-muted', muted);
+        root.setProperty('--page-accent', accent);
+        // The first apply lands instantly (no fade from the pre-size
+        // default); enable the smooth transition only afterwards, so a
+        // live re-theme animates. Next frame, so this apply isn't caught.
+        if (!pageChromeApplied) {
+          pageChromeApplied = true;
+          requestAnimationFrame(function () {
+            document.body.classList.add('theme-transitions');
+          });
+        }
+      }
+      var pageChromeApplied = false;
 
       // Fullscreen: the `fullscreen` class on #terminal drives all
       // layout, so browsers without requestFullscreen on divs (iOS


### PR DESCRIPTION
## What

The viewer already themed the **terminal** (colors ride along in the `size` control message), but the surrounding page — body, header, footer, links — was hardcoded light. A dark terminal therefore sat on a blinding white page.

This derives the page chrome from the terminal theme's own background/foreground, client-side, and exposes it as CSS custom properties (`--page-bg`, `--page-fg`, `--page-muted`, `--page-accent`) on `<html>`. No protocol change — the theme is already on the wire.

## Details

- **Follows the theme tone**: a light theme (e.g. `solarized-light`) gets a light page; a dark theme gets a dark page.
- **Terminal stays a distinct surface**: the page background is *offset* from the terminal background — normally a notch darker (the terminal "floats" above the chrome), but lifted *lighter* when the terminal is near-black (it can't go darker), so the boundary is visible on every theme, even the darkest (`seti`/`tango`).
- **No flash**: the CSS fallbacks are the exact chrome the script computes for the default theme (`tango`), verified equal in-browser (`#222324` / `#cccccc` / `#787979` / `#729fcf`). The theme can't be resolved server-side — the viewer page is rendered once and shared across every room; the theme only arrives later over the WebSocket. So the default before JS runs matters, and it now matches.
- The first apply lands instantly; only live re-themes mid-session animate (0.2s).
- **Scoped to the room page** (`room.css` + the inline script in `room.html`). The home page (`index.css`) and shared `base.css` are untouched.

## Test

New e2e test `test_page_chrome_follows_theme` asserts the page tracks the theme's tone (light page for light theme, dark for dark) **and** that the page background differs from the terminal background (the separation). Full `test_theme.py` suite green (9 passed); `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)