### PR TITLE
Show custom room name in the viewer page title

### DIFF
--- a/e2e/test_room_title.py
+++ b/e2e/test_room_title.py
@@ -1,0 +1,84 @@
+"""
+E2E tests for the room name in the viewer page title.
+
+The viewer puts a user-chosen room name in the tab title, but leaves an
+auto-generated id out (it's noise). It can't see the broadcaster's CLI,
+so it guesses from the name's shape: an auto id is exactly 18 chars from
+[A-Za-z0-9] mixing upper, lower, and digits (see generate_room_id in
+src/cli/mod.rs). The title is set from the URL alone, so these load the
+viewer page directly - no broadcaster required.
+"""
+
+import re
+import subprocess
+
+import pytest
+from playwright.sync_api import sync_playwright
+
+from conftest import CLI_COMMAND, SERVER_URL
+
+DEFAULT_TITLE = "shellshare - live terminal broadcast"
+SHARE_LINK_RE = re.compile(r"Sharing terminal in (\S+)")
+
+
+@pytest.mark.parametrize(
+    "room, expected_title",
+    [
+        # Human-chosen names: shown in the title.
+        ("standup", "standup - shellshare"),
+        ("team-demo", "team-demo - shellshare"),
+        ("Q3Review", "Q3Review - shellshare"),
+        # Auto-generated shape (18 chars, mixed upper/lower/digit): hidden.
+        ("aB3dEf6hIj9kLm2nOp", DEFAULT_TITLE),
+        # 18 chars but no digit / all one case: not the generated shape,
+        # so treated as a custom name and shown.
+        ("abcdefghijklmnopqr", "abcdefghijklmnopqr - shellshare"),
+    ],
+)
+def test_room_name_in_page_title(room, expected_title):
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(f"{SERVER_URL}/r/{room}")
+        page.wait_for_selector("#terminal", timeout=10000)
+        assert page.title() == expected_title
+        browser.close()
+
+
+def test_real_auto_generated_room_keeps_default_title(unique_password):
+    """Lockstep guard: the viewer's heuristic encodes the shape of
+    generate_room_id (src/cli/mod.rs). Run the real CLI so an actual
+    auto-generated id - not a hand-written look-alike - lands in the URL,
+    and assert the title stays default. If the generator drifts out of
+    the heuristic's recognition, this fails instead of silently
+    mistitling every shared room."""
+    # The title comes from the URL alone, so the broadcast need not stay
+    # live; just capture the printed link and visit it.
+    returncode, stdout, stderr = _run_cli("hello", unique_password)
+    assert returncode == 0, f"CLI failed: {stderr}"
+
+    match = SHARE_LINK_RE.search(stdout + stderr)
+    assert match, f"No share link in CLI output: {stdout}\n{stderr}"
+    share_url = match.group(1)
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(share_url)
+        page.wait_for_selector("#terminal", timeout=10000)
+        assert page.title() == DEFAULT_TITLE
+        browser.close()
+
+
+def _run_cli(message, password, server=SERVER_URL, timeout=30):
+    """Run the CLI in stdin mode with no -r, so the room id is
+    auto-generated. Returns (returncode, stdout, stderr)."""
+    proc = subprocess.Popen(
+        CLI_COMMAND + ["--stdin", "-s", server, "-W", password],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    stdout, stderr = proc.communicate(input=message, timeout=timeout)
+    return proc.returncode, stdout, stderr

--- a/templates/room.html
+++ b/templates/room.html
@@ -78,6 +78,30 @@
       var WS_URL =
         (window.location.protocol === 'https:' ? 'wss://' : 'ws://') +
         window.location.host + '/ws/v' + room;
+      // A user-chosen room name goes in the tab title, but an
+      // auto-generated id is noise. We can't see the broadcaster's CLI,
+      // so we guess from the name's shape: generate_room_id (src/cli/
+      // mod.rs) emits exactly 18 chars from [A-Za-z0-9], and random over
+      // 62 symbols it virtually always mixes upper, lower, and digits -
+      // a human "standup" or "team-demo" does not. Mistitling a rare
+      // edge-case tab is harmless, so this cheap heuristic is enough.
+      (function setTitleFromRoom() {
+        var match = /\/r\/([^/]+)\/?$/.exec(window.location.pathname);
+        if (!match) {
+          return;
+        }
+        var name;
+        try {
+          name = decodeURIComponent(match[1]);
+        } catch (e) {
+          name = match[1];
+        }
+        var looksGenerated = /^[A-Za-z0-9]{18}$/.test(name) &&
+          /[a-z]/.test(name) && /[A-Z]/.test(name) && /[0-9]/.test(name);
+        if (!looksGenerated) {
+          document.title = name + ' - shellshare';
+        }
+      })();
       // Broadcasts are end-to-end encrypted by default: the key rides
       // in the URL fragment, which browsers never send to the server,
       // and each message is a sequence of whole records -


### PR DESCRIPTION
## What

A user-chosen room name now appears in the viewer's browser tab title as `<name> - shellshare`. Auto-generated room ids stay out of the title (they're noise nobody wants in a tab).

## How

The room page is a statically-cached template and the URL can't distinguish a custom name from a random id, so the viewer guesses from the name's shape. `generate_room_id` (`src/cli/mod.rs`) emits exactly 18 chars from `[A-Za-z0-9]`; random over 62 symbols those virtually always mix upper, lower, and digits, while a human "standup" or "team-demo" does not:

```js
var looksGenerated = /^[A-Za-z0-9]{18}$/.test(name) &&
  /[a-z]/.test(name) && /[A-Z]/.test(name) && /[0-9]/.test(name);
```

The title is set from the URL alone at page load — no wire-protocol change, no waiting for a live broadcaster. Mistitling a rare edge-case tab is harmless.

## Guarding the duplication

The heuristic re-encodes the generator's shape in JS. To keep that from drifting silently, `test_real_auto_generated_room_keeps_default_title` runs the **real** CLI so a genuine generated id flows through the viewer: if the generator ever changes out of the heuristic's recognition, CI fails loudly instead of silently mistitling every shared room.

## Tests

`e2e/test_room_title.py` — custom names shown, auto-generated shape hidden, a near-miss (18 chars but single-case) shown, plus the real-CLI lockstep guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)