### PR TITLE
test: fix stale Inconsolata preload assertion (unbreak main after #156)

### DIFF
--- a/e2e/test_caching.py
+++ b/e2e/test_caching.py
@@ -69,7 +69,7 @@ class TestPageCaching:
         link = headers.get('Link', '')
         for asset in ['xterm.js', 'xterm-addon-webgl.js',
                       'xterm-addon-unicode11.js',
-                      'Inconsolata-latin.woff2']:
+                      'Inconsolata.woff2']:
             assert asset in link, f"Link preload header must announce {asset}"
             assert re.search(rf'{re.escape(asset)}\?v=[0-9a-f]+', body), \
                 f"{asset} must be referenced with a content-hash version"


### PR DESCRIPTION
#156 squash-merged with the font asset renamed (`Inconsolata-latin.woff2` → `Inconsolata.woff2`), but the matching one-line update to the Early-Hints lockstep test in `test_caching.py` didn't make it into that merge — so `main` is currently red on `test_room_page_announces_preloads`.

This points the assertion at the merged asset name. Verified locally (`1 passed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)