### PR TITLE
Print share QR code in terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,6 +1212,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,6 +1725,7 @@ dependencies = [
  "mime_guess",
  "percent-encoding",
  "portable-pty",
+ "qrcode",
  "rand 0.8.6",
  "reqwest",
  "rust-embed",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ machine-uid = "0.6.0"
 hkdf = "0.12.4"
 dashmap = "6.2.1"
 futures-util = { version = "0.3.32", default-features = false, features = ["std", "sink"] }
+qrcode = { version = "0.14.1", default-features = false }
 
 [profile.release]
 lto = true

--- a/e2e/test_agents.py
+++ b/e2e/test_agents.py
@@ -95,6 +95,7 @@ class TestJsonContract:
             timeout=CLI_SESSION_TIMEOUT,
         )
         assert "Sharing terminal in" not in proc.stdout + proc.stderr
+        assert "Scan this QR code" not in proc.stdout + proc.stderr
         assert "End of transmission" not in proc.stdout + proc.stderr
 
 

--- a/e2e/test_cli_tty.py
+++ b/e2e/test_cli_tty.py
@@ -248,6 +248,19 @@ class TestTtyBroadcast:
         cli.send("exit\n")
         cli.wait_exit()
 
+    def test_terminal_output_includes_phone_qr_code(
+        self, unique_room, unique_password, tty_cli
+    ):
+        cli = tty_cli(unique_room, unique_password)
+        assert cli.wait_for_screen("Scan this QR code with your phone:"), (
+            f"No QR prompt on CLI screen. Screen: {cli.screen!r}"
+        )
+        assert any(ch in cli.screen for ch in "▀▄█"), (
+            f"No terminal QR block characters on CLI screen. Screen: {cli.screen!r}"
+        )
+        cli.send("exit\n")
+        cli.wait_exit()
+
 
 class TestTtyResize:
     """Resizing the terminal must propagate to viewers."""

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -12,6 +12,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use crate::protocol::TermSize;
+use qrcode::{render::unicode, QrCode};
 use rand::Rng;
 
 /// Get the current terminal size using ioctl (TIOCGWINSZ) via `term_size`.
@@ -126,6 +127,28 @@ fn emit_json(event: &serde_json::Value) {
     let _ = io::stdout().flush();
 }
 
+/// Render a compact terminal QR code for the share URL. Failure should
+/// never prevent a broadcast; the plain link remains the source of truth.
+fn render_qr_code(url: &str) -> Option<String> {
+    QrCode::new(url.as_bytes())
+        .ok()
+        .map(|code| code.render::<unicode::Dense1x2>().build())
+}
+
+fn emit_human_sharing_message<W: Write>(writer: &mut W, share_url: &str, show_qr: bool) {
+    let _ = writeln!(writer, "Sharing terminal in {share_url}");
+
+    if show_qr {
+        if let Some(qr) = render_qr_code(share_url) {
+            let _ = writeln!(writer);
+            let _ = writeln!(writer, "Scan this QR code with your phone:");
+            let _ = writeln!(writer, "{qr}");
+        }
+    }
+
+    let _ = writer.flush();
+}
+
 /// Run the shellshare client. Returns the exit code to propagate: the
 /// child command's status for `exec`, otherwise 0.
 pub fn run(args: ClientArgs) -> Result<i32, Box<dyn std::error::Error>> {
@@ -196,7 +219,9 @@ pub fn run(args: ClientArgs) -> Result<i32, Box<dyn std::error::Error>> {
     let exit_code = if args.stdin {
         // Stdin mode - prose goes to stderr (stdout may be piped onward)
         if !args.json {
-            eprintln!("Sharing terminal in {share_url}");
+            let mut stderr = io::stderr();
+            let show_qr = stderr.is_terminal();
+            emit_human_sharing_message(&mut stderr, &share_url, show_qr);
         }
 
         // Read from stdin and stream to server
@@ -217,7 +242,9 @@ pub fn run(args: ClientArgs) -> Result<i32, Box<dyn std::error::Error>> {
                 println!("You can resize it anytime.");
             }
 
-            println!("Sharing terminal in {share_url}");
+            let mut stdout = io::stdout();
+            let show_qr = stdout.is_terminal();
+            emit_human_sharing_message(&mut stdout, &share_url, show_qr);
         }
 
         // Run script mode with PTY


### PR DESCRIPTION
## Summary
- print a terminal QR code beside the human-readable share URL on TTY output
- keep --json output prose-free for scripts and agents
- cover QR TTY output and JSON suppression in e2e tests

## Verification
- make lint
- uv run pytest test_agents.py::TestJsonContract::test_json_mode_suppresses_prose test_cli_tty.py::TestTtyBroadcast::test_terminal_output_includes_phone_qr_code
- independent code-reviewer subagent: no findings