### PR TITLE
feat: add `shellshare status` to re-print a session's link + QR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,13 @@ embedded server on localhost (nothing leaves the machine); add `--tunnel` to
 get a public `https://*.trycloudflare.com` link without using shellshare.net
 (requires `cloudflared` installed).
 
+**Recover the link from inside a session** — `shellshare status` re-prints
+the current broadcast's link (and QR code). With `--json` it prints a single
+object `{"url":"...","room":"..."}`; outside a live session it prints
+`ERROR: ...` to stderr and exits non-zero. It reads the link from the
+`SHELLSHARE_URL` environment variable the broadcaster exports into the shell
+it spawns, so it only works from within that shell.
+
 ## Behavior worth knowing
 
 - One-way only: viewers cannot send input to the terminal.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ your network. The key is derived from your computer and the room name, so
 re-broadcasting to a named room from the same machine reproduces the same
 link, and a link you've already shared keeps working.
 
+Lost the link after it scrolled off screen? From inside the shared shell,
+run `shellshare status` to re-print the link and its QR code. It reads the
+link from the environment of the session you're in, so it only works from
+within a live broadcast — and nothing is written to disk.
+
 ### Scripting & AI agents
 
 shellshare is built to be driven by scripts and AI agents — for example, an

--- a/e2e/test_agents.py
+++ b/e2e/test_agents.py
@@ -3,11 +3,13 @@ E2E tests for the machine-readable surfaces aimed at scripts and AI agents:
 
 - The CLI's --json output contract (stdin mode and exec mode)
 - The `exec` subcommand: single command, live broadcast, exit code propagation
+- `shellshare status --json`: recovering a live session's link from the env
 - The discovery endpoints the website serves: /llms.txt, /robots.txt,
   /sitemap.xml, and the structured data on the home page
 """
 
 import json
+import os
 import platform
 import subprocess
 
@@ -209,3 +211,45 @@ class TestDiscoveryEndpoints:
         assert 'application/ld+json' in response.text
         assert '"SoftwareApplication"' in response.text
         assert '"FAQPage"' in response.text
+
+
+class TestStatusContract:
+    """`shellshare status --json`: recover the live session's link.
+
+    The broadcaster exports the share URL into the shell it spawns
+    (`SHELLSHARE_URL`); `status` reads it back. No server or broadcast is
+    needed to exercise the contract - just the environment.
+    """
+
+    def test_status_json_reads_session_from_env(self):
+        url = f"{SERVER_URL}/r/demo-status#{'a' * 64}"
+        proc = subprocess.run(
+            CLI_COMMAND + ["status", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=CLI_SESSION_TIMEOUT,
+            env={
+                **os.environ,
+                "SHELLSHARE_URL": url,
+                "SHELLSHARE_ROOM": "demo-status",
+            },
+        )
+        assert proc.returncode == 0
+        assert json.loads(proc.stdout.strip()) == {
+            "url": url,
+            "room": "demo-status",
+        }
+
+    def test_status_json_outside_session_errors(self):
+        env = {k: v for k, v in os.environ.items() if k != "SHELLSHARE_URL"}
+        proc = subprocess.run(
+            CLI_COMMAND + ["status", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=CLI_SESSION_TIMEOUT,
+            env=env,
+        )
+        # The --json contract: errors on stderr, nothing on stdout, exit 1.
+        assert proc.returncode == 1
+        assert proc.stdout.strip() == ""
+        assert "ERROR" in proc.stderr

--- a/e2e/test_cli_tty.py
+++ b/e2e/test_cli_tty.py
@@ -261,6 +261,38 @@ class TestTtyBroadcast:
         cli.send("exit\n")
         cli.wait_exit()
 
+    def test_status_reprints_link_and_qr_from_inside_session(
+        self, unique_room, unique_password, tty_cli
+    ):
+        cli = tty_cli(unique_room, unique_password)
+        assert cli.wait_for_screen("Sharing terminal in"), (
+            f"CLI did not start sharing. Screen: {cli.screen!r}"
+        )
+        key = parse_share_key(cli.screen)
+        assert key, f"No share key on CLI screen. Screen: {cli.screen!r}"
+
+        # `shellshare status`, run from inside the shared shell, recovers
+        # the link from the environment the broadcaster exported into the
+        # shell it spawned - nothing was written to disk.
+        cli.send(f"{CLI_PATH} status\n")
+        assert cli.wait_for_screen("Sharing this terminal at"), (
+            f"status did not reprint the link. Screen: {cli.screen!r}"
+        )
+        # A second QR block appears (the first was the startup banner's).
+        assert poll_until(
+            lambda: cli.screen.count("Scan this QR code with your phone:") >= 2,
+            timeout=10,
+        ), f"status did not print a QR code. Screen: {cli.screen!r}"
+        # The recovered link carries the same #fragment key: the exact URL
+        # rode through the environment, so there is no re-derivation that
+        # could silently diverge from the live broadcast.
+        assert cli.screen.count(key) >= 2, (
+            f"status link key did not match the broadcast. Screen: {cli.screen!r}"
+        )
+
+        cli.send("exit\n")
+        cli.wait_exit()
+
 
 class TestTtyResize:
     """Resizing the terminal must propagate to viewers."""

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -50,6 +50,11 @@ Recipes:
 - Live-only: broadcasts are not recorded. Rooms are deleted when the
   broadcast ends or after a period of inactivity.
 - Late joiners see recent history, not a blank page.
+- `shellshare status`, run from inside a live session, re-prints that
+  session's link and QR code (read from the `SHELLSHARE_URL` env var the
+  broadcaster exports into the spawned shell; nothing is written to disk).
+  With `--json` it prints `{"url":"...","room":"..."}`; outside a session it
+  errors on stderr and exits non-zero.
 - Network drops are handled: output is buffered and replayed on reconnect.
 - `--theme` sets viewer colors (asciinema themes: dracula, gruvbox-dark,
   monokai, nord, seti, solarized-dark, solarized-light, tango, asciinema).

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -50,6 +50,19 @@ pub struct ClientArgs {
     pub encrypt: bool,
 }
 
+/// Environment variable carrying the live broadcast's share URL into the
+/// spawned shell, so `shellshare status` can re-print it from inside the
+/// session. Kept in memory only - never written to disk.
+pub const ENV_URL: &str = "SHELLSHARE_URL";
+/// Environment variable carrying the live broadcast's room name.
+pub const ENV_ROOM: &str = "SHELLSHARE_ROOM";
+
+/// The live session details exported into the spawned shell's environment.
+pub struct SessionEnv<'a> {
+    pub url: &'a str,
+    pub room: &'a str,
+}
+
 /// Generate a random 18-character alphanumeric room ID
 fn generate_room_id() -> String {
     const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
@@ -135,18 +148,61 @@ fn render_qr_code(url: &str) -> Option<String> {
         .map(|code| code.render::<unicode::Dense1x2>().build())
 }
 
+/// Write the phone-scannable QR block for `url`, prefixed by an invitation
+/// line. Best-effort: a QR render failure leaves the plain link as the
+/// source of truth and prints nothing.
+fn write_qr_code<W: Write>(writer: &mut W, url: &str) {
+    if let Some(qr) = render_qr_code(url) {
+        let _ = writeln!(writer);
+        let _ = writeln!(writer, "Scan this QR code with your phone:");
+        let _ = writeln!(writer, "{qr}");
+    }
+}
+
 fn emit_human_sharing_message<W: Write>(writer: &mut W, share_url: &str, show_qr: bool) {
     let _ = writeln!(writer, "Sharing terminal in {share_url}");
 
     if show_qr {
-        if let Some(qr) = render_qr_code(share_url) {
-            let _ = writeln!(writer);
-            let _ = writeln!(writer, "Scan this QR code with your phone:");
-            let _ = writeln!(writer, "{qr}");
-        }
+        write_qr_code(writer, share_url);
     }
 
     let _ = writer.flush();
+}
+
+/// `shellshare status`: re-print the link (and QR) for the broadcast this
+/// terminal is part of. The share URL is read from the `SHELLSHARE_URL`
+/// environment variable that the broadcaster exports into the shell it
+/// spawns, so this works only from inside a live shellshare session - and
+/// without anything having been written to disk. Returns the exit code:
+/// 0 when a session is found, 1 otherwise.
+pub fn status(json: bool) -> i32 {
+    let url = std::env::var(ENV_URL).ok().filter(|u| !u.is_empty());
+    let Some(url) = url else {
+        if json {
+            // Mirror the --json contract: errors go to stderr, exit non-zero.
+            eprintln!("ERROR: not inside a shellshare session");
+        } else {
+            eprintln!(
+                "Not inside a shellshare session. Run `shellshare` first, then \
+                 `shellshare status` from within the shared shell to see the link."
+            );
+        }
+        return 1;
+    };
+
+    if json {
+        let room = std::env::var(ENV_ROOM).ok();
+        emit_json(&serde_json::json!({ "url": url, "room": room }));
+        return 0;
+    }
+
+    let mut stdout = io::stdout();
+    let _ = writeln!(stdout, "Sharing this terminal at {url}");
+    if stdout.is_terminal() {
+        write_qr_code(&mut stdout, &url);
+    }
+    let _ = stdout.flush();
+    0
 }
 
 /// Run the shellshare client. Returns the exit code to propagate: the
@@ -247,8 +303,13 @@ pub fn run(args: ClientArgs) -> Result<i32, Box<dyn std::error::Error>> {
             emit_human_sharing_message(&mut stdout, &share_url, show_qr);
         }
 
-        // Run script mode with PTY
-        let code = script::run_script_mode(transport, &running, args.exec.as_deref())?;
+        // Run script mode with PTY. The share URL and room ride into the
+        // shell's environment so `shellshare status` can recover the link.
+        let session = SessionEnv {
+            url: &share_url,
+            room: &room,
+        };
+        let code = script::run_script_mode(transport, &running, args.exec.as_deref(), &session)?;
 
         if !args.json {
             println!("End of transmission.");

--- a/src/cli/script.rs
+++ b/src/cli/script.rs
@@ -89,11 +89,17 @@ impl RawModeGuard {
 /// Run script mode - spawn a shell (or, for `exec`, a single command) in a
 /// PTY and stream output to server. Returns the exit code to propagate:
 /// the child's status when it can be observed, otherwise 0.
+///
+/// `session` carries the share URL and room name; they are exported into
+/// the spawned process's environment (`SHELLSHARE_URL`, `SHELLSHARE_ROOM`)
+/// so `shellshare status`, run from inside the shared shell, can re-print
+/// the link and QR code without anything being written to disk.
 #[allow(clippy::too_many_lines)] // Complex PTY setup with multiple threads
 pub fn run_script_mode(
     transport: ws::Transport,
     running: &Arc<AtomicBool>,
     exec: Option<&[String]>,
+    session: &super::SessionEnv<'_>,
 ) -> Result<i32, Box<dyn std::error::Error>> {
     // Enable raw mode BEFORE spawning shell
     // This allows character-by-character input and proper escape sequence handling
@@ -134,6 +140,16 @@ pub fn run_script_mode(
     };
     if let Ok(cwd) = std::env::current_dir() {
         cmd.cwd(cwd);
+    }
+    // Export the live session into the spawned shell's environment so
+    // `shellshare status`, run from inside it, can recover the link -
+    // kept in memory only, never written to disk. Only for an interactive
+    // shell: `exec` runs one arbitrary command that can't usefully call
+    // `status` and might forward its environment onward (CI logs, crash
+    // reporters), so it must not carry the URL's secret #fragment.
+    if exec.is_none() {
+        cmd.env(super::ENV_URL, session.url);
+        cmd.env(super::ENV_ROOM, session.room);
     }
 
     // Spawn the shell in the PTY

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,6 +128,9 @@ enum Commands {
         #[arg(long)]
         tunnel: bool,
     },
+    /// Show the share link (and QR code) for the broadcast this terminal
+    /// is part of. Run it from inside a live `shellshare` session.
+    Status,
     /// Run a single command, share its output live, and exit with its
     /// exit code when it finishes (designed for scripts and AI agents)
     Exec {
@@ -322,6 +325,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 encrypt: !cli.disable_encryption,
             };
             serve(&host, port, tunnel, share);
+        }
+        Some(Commands::Status) => {
+            std::process::exit(cli::status(cli.json));
         }
         Some(Commands::Exec { command }) => {
             // The stdin branch would win and silently drop the command


### PR DESCRIPTION
## Why

When you're inside a live `shellshare` broadcast and the share link has scrolled off the screen, there's no way to get it back short of restarting. This adds `shellshare status` — run it from inside the shared shell to re-print the current broadcast's link and its phone QR code.

## How it works

The broadcaster exports the share URL and room into the environment of the shell it spawns (`SHELLSHARE_URL`, `SHELLSHARE_ROOM`); `status`, run from inside that shell, reads them back. Key properties:

- **Nothing is written to disk** — the URL lives in memory only, preserving the no-disk invariant documented in `crypto.rs`. (This is why it shows *only the current session*, not a machine-wide registry — that would mean discovering/persisting other processes' links.)
- **The exact URL is reconstructed verbatim**, including the `#fragment` decryption key — no key re-derivation that could silently diverge from the live broadcast.
- **`exec` does not carry the vars.** `shellshare exec -- <cmd>` runs one arbitrary command that can't usefully call `status` and might forward its environment onward (CI logs, crash reporters), so it must not leak the URL's secret `#fragment`. Only the interactive shell gets them.

## Example output

From inside a live session, `shellshare status`:

> ```
> Sharing this terminal at https://shellshare.net/r/h2Uont4F8bvZ8VDjHb#3f9a...key
>
> Scan this QR code with your phone:
>
>     █▀▀▀▀▀█ █▄ ▀ █  █▄▄▀▀█▀█  █▀▀▀▀▀█
>     █ ███ █ ▄  █▄ ▄▀▄▄▀▀▀ ▄▄▀ █ ███ █
>     █ ▀▀▀ █  ▀▀▄ ▀█  ▀██▄▄▄ ▄ █ ▀▀▀ █
>     ▀▀▀▀▀▀▀ █ █▄▀ █ ▀▄▀▄█ █ ▀ ▀▀▀▀▀▀▀
>     █ ▀▀▄█▀█▄  ▀▀ █ ██▄▄▄█ ▄  █▄ █▄██
>       ██▄▄▀█ ▀██ ▄█ ▀▀▄ █▀█▀▄███▀█ ▄█
>     ▄ ▄▀█▄▀ █▄█ ▄  ▀▄ ▀█ ▄▄▀▀▀▄▄ █▄█
>      ▀  ▀█▀█▄▄▀▄██▀▀█▀▀█▄▄▀▄▄▄█▄█▄▄
>     ▄ ▄ ▀█▀▀▀ ▄▄ ▄██ ▀ ▄ ▀▄▄▄▀▄▀█ ▀▀▄
>     ▀  ▀  ▀ ▄ ▀  ▀██▀█▀█▄ ███▀▀▀██ █
>     █▀▀▀▀▀█ █▄▄▄▄▀█▄▀  ▀█▄███ ▀ █▄▄▀
>     █ ▀▀▀ █ ▀█ ▀ ██▄▄█▄▄   ▄  ▀█▄   ▄
>     ▀▀▀▀▀▀▀ ▀▀▀▀▀  ▀▀▀▀  ▀ ▀ ▀▀ ▀▀
> ```

The QR is only drawn when stdout is a TTY (skipped when piped, like the startup banner).

With `--json`, a single self-contained object (distinct from the streaming `{"event":...}` contract):

> ```
> {"url":"https://shellshare.net/r/h2Uont4F8bvZ8VDjHb#3f9a...key","room":"h2Uont4F8bvZ8VDjHb"}
> ```

Run outside a live session, it points the way and exits non-zero:

> ```
> Not inside a shellshare session. Run `shellshare` first, then `shellshare status` from within the shared shell to see the link.
> ```
>
> (`--json` instead prints `ERROR: not inside a shellshare session` to stderr, exit 1 — matching the existing `--json` convention.)

## Tests

- `test_cli_tty.py`: from inside a live TTY broadcast, `shellshare status` reprints the link and a second QR block, and the recovered `#fragment` key matches the live broadcast's (verifies the env plumbing end-to-end).
- `test_agents.py`: the `status --json` single-object shape, and the outside-a-session error contract (stderr + exit 1).

Docs updated in lockstep: `README.md`, `AGENTS.md`, `public/llms.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)