### PR TITLE
fix: preserve idle WebGL terminal screen

### DIFF
--- a/e2e/test_broadcast.py
+++ b/e2e/test_broadcast.py
@@ -409,6 +409,45 @@ def test_resize_updates_browser_terminal():
         browser.close()
 
 
+def test_webgl_renderer_preserves_idle_screen_buffer(dedicated_server):
+    """
+    xterm's WebGL renderer only redraws dirty rows. The viewer must ask
+    the browser to preserve the WebGL drawing buffer so a settled screen
+    does not fade to black while only animated cells keep repainting.
+    """
+    server = dedicated_server()
+    room_id = f"webgl-{random_id()}"
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.add_init_script(
+            """
+            (() => {
+              const originalGetContext = HTMLCanvasElement.prototype.getContext;
+              HTMLCanvasElement.prototype.getContext = function(type, attrs) {
+                if (type === 'webgl2') {
+                  window.__shellshareWebgl2ContextAttributes = attrs || {};
+                }
+                return originalGetContext.apply(this, arguments);
+              };
+            })();
+            """
+        )
+
+        page.goto(f"{server.url}/r/{room_id}")
+        page.wait_for_function(
+            "window.term && "
+            "window.__shellshareWebgl2ContextAttributes !== undefined",
+            timeout=10000,
+        )
+
+        attrs = page.evaluate("window.__shellshareWebgl2ContextAttributes")
+        assert attrs.get("preserveDrawingBuffer") is True
+
+        browser.close()
+
+
 def test_fullscreen_mode_scales_and_restores():
     """
     Pressing `f` enters fullscreen: #terminal gets the `fullscreen`

--- a/templates/room.html
+++ b/templates/room.html
@@ -377,7 +377,9 @@
           return;
         }
         try {
-          var webgl = new WebglAddon.WebglAddon();
+          // Static terminal panes must survive browser compositor idle
+          // clears; otherwise only cells that keep changing repaint.
+          var webgl = new WebglAddon.WebglAddon(true);
           webgl.onContextLoss(function () {
             webgl.dispose();
           });


### PR DESCRIPTION
## Summary
- Request a preserved drawing buffer for xterm's WebGL renderer in the viewer.
- Keep the existing DOM fallback and context-loss handling unchanged.
- Add a browser regression test that asserts the viewer asks WebGL2 for `preserveDrawingBuffer: true`.

## Root Cause
The viewer created `new WebglAddon.WebglAddon()` with the default drawing-buffer behavior. The vendored xterm WebGL addon forwards that value to `canvas.getContext('webgl2', { preserveDrawingBuffer })`.

When the browser/compositor clears a non-preserved WebGL drawing buffer while the terminal is idle, xterm only redraws dirty rows. Static cells can go black, while animated cells keep repainting. That matches the reported behavior where only the rolling loader remains visible.

## Caveats
- The regression test is a contract test, not a visual reproduction. It proves the viewer requests `preserveDrawingBuffer: true`; it does not prove a real GPU/browser no longer blacks out during an idle session.
- CI/headless Chromium does not expose WebGL2 in this environment, so a screenshot/pixel test would exercise the DOM fallback instead of the affected WebGL path.
- `preserveDrawingBuffer: true` can cost some GPU memory/compositor performance because the browser cannot freely discard the drawing buffer. This is a correctness tradeoff for a read-only terminal viewer where static screens must remain visible.
- If a browser loses the WebGL context entirely, this change does not prevent that. The existing `onContextLoss` path still disposes WebGL and falls back to xterm's non-WebGL renderer.

## Verification
- `cargo build --release`
- `make lint`
- `uv run pytest test_broadcast.py::test_webgl_renderer_preserves_idle_screen_buffer`
- `uv run pytest -n 10` (243 passed)
