### PR TITLE
feat: keyframes so late joiners see full-screen TUIs (#164)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "avt"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "156203bcce48a54533c6a718509c22825c1ebbb606e6b313a6f13e8c6097bd13"
+dependencies = [
+ "rgb",
+ "unicode-width",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +220,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "bytes"
@@ -1354,6 +1370,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,6 +1735,7 @@ name = "shellshare"
 version = "3.6.1"
 dependencies = [
  "aes-gcm",
+ "avt",
  "axum",
  "bytes",
  "clap",
@@ -2174,6 +2200,12 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ hkdf = "0.12.4"
 dashmap = "6.2.1"
 futures-util = { version = "0.3.32", default-features = false, features = ["std", "sink"] }
 qrcode = { version = "0.14.1", default-features = false }
+avt = "0.16.0"
 
 [profile.release]
 lto = true

--- a/e2e/test_keyframe.py
+++ b/e2e/test_keyframe.py
@@ -1,0 +1,193 @@
+"""
+RED acceptance test for shellshare#164: a late joiner to a long-running
+full-screen TUI must still see the static parts of the screen, not only the
+cells that keep changing.
+
+A full-screen TUI paints the whole screen once (enter alt screen, clear, draw
+the chrome) and then emits only small incremental updates forever. The server
+keeps a bounded replay log for late joiners (`MessageHistory`,
+`MAX_HISTORY_MESSAGES = 200`), so after >200 incremental frames the initial full
+paint is evicted and a late joiner replays only the changing region - a mostly
+blank screen with a lonely counter.
+
+The fix is broadcaster-side encrypted keyframes (issue #164): the CLI runs a
+headless terminal emulator and periodically broadcasts a sealed full-screen
+redraw, so a late joiner always reconstructs the whole screen.
+
+This test fails today (the viewer never renders the static chrome) and should
+pass once keyframes land. The assertion is made against the real viewer
+(xterm.js via `window.shellshareText()`), so it is independent of exactly how a
+keyframe serializes the screen - it only asserts what a user actually sees.
+"""
+
+import subprocess
+import time
+
+from conftest import (
+    CLI_COMMAND,
+    SERVER_URL,
+    SocketListener,
+    parse_share_key,
+    wait_for_content,
+    wait_for_terminal_text,
+)
+from playwright.sync_api import sync_playwright
+
+# Painted once at the top of the screen, then never re-sent.
+STATIC_MARKER = "DASHBOARD"
+# Enter alt screen + clear, then a 3-line frame whose top line carries the
+# marker; this is the "base paint" a real TUI does once on startup.
+BASE_PAINT = (
+    "\x1b[?1049h\x1b[2J\x1b[H"
+    "\x1b[1;1H+==== DASHBOARD ====+"
+    "\x1b[2;1H| loading...        |"
+    "\x1b[3;1H+===================+"
+)
+# Comfortably more than MAX_HISTORY_MESSAGES (200) so the base paint is evicted
+# well before a late joiner connects. Each update is its own history frame.
+NUM_UPDATES = 300
+LAST_COUNTER = f"C={NUM_UPDATES - 1:05d}"  # "C=00299"
+FIRST_COUNTER = "C=00000"
+# Spacing so each write lands in its own stdin read -> its own history frame
+# (the CLI coalesces only what is already queued).
+STEP_SECONDS = 0.02
+
+
+def _start_broadcaster(room, password):
+    """Start a long-lived encrypted `--stdin` broadcast; return (proc, key).
+
+    `--stdin` broadcasts raw stdin bytes directly (no inner shell/PTY), so the
+    test emits an exact alt-screen byte stream and controls frame boundaries
+    from Python.
+    """
+    proc = subprocess.Popen(
+        CLI_COMMAND + ["--stdin", "-s", SERVER_URL, "-r", room, "-W", password],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    # The share link (with the #key fragment) is printed at startup, before any
+    # stdin is consumed.
+    deadline = time.time() + 10
+    seen = ""
+    key = None
+    while time.time() < deadline and key is None:
+        line = proc.stderr.readline()
+        if not line:
+            break
+        seen += line
+        key = parse_share_key(seen)
+    assert key, f"No share key printed by broadcaster: {seen!r}"
+    return proc, key
+
+
+def _finish(proc):
+    try:
+        proc.stdin.close()
+    except (BrokenPipeError, OSError):
+        pass
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def test_late_joiner_sees_static_chrome_of_long_running_tui(
+    unique_room, unique_password
+):
+    proc, key = _start_broadcaster(unique_room, unique_password)
+    try:
+        # Paint the full screen once, then update only one cell, many times.
+        proc.stdin.write(BASE_PAINT)
+        proc.stdin.flush()
+        for i in range(NUM_UPDATES):
+            proc.stdin.write(f"\x1b[5;1HC={i:05d}")
+            proc.stdin.flush()
+            time.sleep(STEP_SECONDS)
+
+        # Precondition: the base paint really was evicted. A late joiner's
+        # snapshot carries the recent counter but no longer the earliest one.
+        peek = SocketListener(unique_room)
+        peek.connect()
+        peek.set_key(key)
+        assert wait_for_content(
+            peek, lambda s: LAST_COUNTER in s, timeout=10
+        ), "late joiner never received the live counter"
+        snapshot = peek.get_accumulated_messages()
+        peek.disconnect()
+        assert FIRST_COUNTER not in snapshot, (
+            "history was not evicted - raise NUM_UPDATES "
+            f"(snapshot head: {snapshot[:80]!r})"
+        )
+
+        # Behavior under test: a freshly-loaded viewer renders the static
+        # chrome, not just the changing cell.
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page()
+            page.goto(f"{SERVER_URL}/r/{unique_room}#{key}")
+            # Sanity: the viewer is alive and rendering the changing region.
+            wait_for_terminal_text(page, LAST_COUNTER)
+            # RED today: the static chrome was evicted and never re-sent, so
+            # this times out. Keyframes (#164) make it pass.
+            wait_for_terminal_text(page, STATIC_MARKER, timeout=8000)
+            browser.close()
+    finally:
+        _finish(proc)
+
+
+def test_no_keyframes_leak_into_scrollback_after_alt_exit(
+    unique_room, unique_password
+):
+    """A TUI that enters the alternate screen, saves a cursor, then EXITS and
+    resumes normal scrolling must NOT get keyframes injected into its
+    scrollback.
+
+    avt's screen dump emits the alternate-screen switch (`?1047h`) not only
+    while on the alt screen but also afterwards, whenever a cursor was ever
+    saved there (`vim`/`less`/`htop`/git pager all do). So the emit gate must
+    key off the CURRENT screen (an *unpaired* `?1047h`), not merely "the dump
+    mentions `?1047h`" - otherwise every common TUI keeps re-injecting a
+    full-screen redraw into a plain scrolling session, corrupting connected
+    viewers. (Caught in the #164 implementation review.)
+    """
+    proc, key = _start_broadcaster(unique_room, unique_password)
+    try:
+        # Brief alt-screen TUI that SAVES a non-home cursor (ESC 7), kept under
+        # the keyframe cadence so no (legitimate) keyframe fires while on alt.
+        # The cursor must be off home before the save: avt's default saved
+        # context is the home position, so a home-position save stays "default"
+        # and would not leave the lingering alt context that triggers the bug.
+        proc.stdin.write("\x1b[?1049h\x1b[2J\x1b[5;10H\x1b7\x1b[HALTMARK")
+        proc.stdin.flush()
+        for i in range(5):
+            proc.stdin.write(f"\x1b[3;1Ht={i}")
+            proc.stdin.flush()
+            time.sleep(STEP_SECONDS)
+        proc.stdin.write("\x1b[?1049l")  # exit the alternate screen
+        proc.stdin.flush()
+        # Resume normal scrolling well past a keyframe interval.
+        for i in range(120):
+            proc.stdin.write(f"LINE-{i:04d}\r\n")
+            proc.stdin.flush()
+            time.sleep(STEP_SECONDS)
+
+        late = SocketListener(unique_room)
+        late.connect()
+        late.set_key(key)
+        assert wait_for_content(
+            late, lambda s: "LINE-0119" in s, timeout=10
+        ), "late joiner never received the scrolled output"
+        snapshot = late.get_accumulated_messages()
+        late.disconnect()
+        # A keyframe normalizes avt's alt switch to `ESC[?1047`; the broadcaster
+        # itself only ever sent `ESC[?1049{h,l}`. So any `?1047` in the snapshot
+        # is a keyframe wrongly injected into a primary-screen session.
+        assert "\x1b[?1047" not in snapshot, (
+            "keyframe leaked into post-alt-exit scrollback "
+            f"(snapshot tail: {snapshot[-120:]!r})"
+        )
+    finally:
+        _finish(proc)

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,6 +4,7 @@
 //! output to a shellshare server.
 
 mod crypto;
+mod screen;
 mod script;
 mod ws;
 

--- a/src/cli/screen.rs
+++ b/src/cli/screen.rs
@@ -1,0 +1,149 @@
+//! Periodic full-screen "keyframes" for late joiners (issue #164).
+//!
+//! A long-running full-screen TUI paints the screen once and then emits only
+//! incremental updates. The server keeps a bounded replay history, so the
+//! initial full paint is evicted and a late joiner sees only the changing
+//! cells. This module runs a headless terminal emulator (`avt`) over the exact
+//! broadcast byte stream and, on a cadence, produces a self-contained redraw of
+//! the current screen. The redraw is broadcast as ordinary (sealed) output, so
+//! it lands in history and a late joiner reconstructs the whole screen.
+//!
+//! Keyframes are produced ONLY for alternate-screen sessions (full-screen
+//! TUIs). A normal scrolling shell keeps raw-history behavior untouched, so its
+//! scrollback is never replaced by a visible-screen-only snapshot.
+
+use crate::protocol::TermSize;
+
+/// Emit a keyframe at most once per this many broadcast frames. Kept well below
+/// the server's 200-message history cap (`MAX_HISTORY_MESSAGES`) so a recent
+/// keyframe survives in the window a late joiner replays. Note this counts
+/// *fed frames*, not stored history messages - the sender coalesces reads, so
+/// one fed frame need not be one history message; the wide margin absorbs that.
+const FRAMES_PER_KEYFRAME: u32 = 60;
+
+/// Cap on carried bytes. A valid incomplete UTF-8 tail is at most 3 bytes;
+/// anything larger means malformed input, so the carry is dropped to resync.
+const MAX_CARRY: usize = 8;
+
+/// Runs a headless terminal over the broadcast stream and produces keyframes.
+pub struct Keyframer {
+    vt: avt::Vt,
+    cols: usize,
+    rows: usize,
+    /// Bytes that ended mid-UTF-8 sequence, carried to the next feed.
+    carry: Vec<u8>,
+    /// Broadcast frames fed since the last keyframe (or since start).
+    frames_since: u32,
+}
+
+impl Keyframer {
+    pub fn new(size: TermSize) -> Self {
+        let cols = usize::from(size.cols.max(1));
+        let rows = usize::from(size.rows.max(1));
+        Self {
+            vt: avt::Vt::new(cols, rows),
+            cols,
+            rows,
+            carry: Vec::new(),
+            frames_since: 0,
+        }
+    }
+
+    /// Feed one broadcast frame's plaintext bytes and count it. Resizes the
+    /// emulator first when the terminal size changed.
+    pub fn feed(&mut self, data: &[u8], size: TermSize) {
+        self.apply_resize(size);
+        if data.is_empty() {
+            return;
+        }
+        self.feed_bytes(data);
+        self.frames_since = self.frames_since.saturating_add(1);
+    }
+
+    /// The keyframe to broadcast now, or `None`. Emits only when the cadence is
+    /// due AND the session is on the alternate screen (a full-screen TUI).
+    pub fn maybe_keyframe(&mut self) -> Option<Vec<u8>> {
+        if self.frames_since < FRAMES_PER_KEYFRAME {
+            return None;
+        }
+        // Reset on every due check, even when gated out below: a primary-screen
+        // session must not bank a backlog of keyframes that all fire the instant
+        // it enters the alternate screen.
+        self.frames_since = 0;
+        // `dump()` allocates a redraw of the whole screen; on a primary-screen
+        // (scrolling) session this runs every `FRAMES_PER_KEYFRAME` frames only
+        // to be discarded by the gate below. Acceptable for now (see #164).
+        let dump = self.vt.dump();
+        // Emit only while the session is CURRENTLY on the alternate screen (a
+        // live full-screen TUI). avt's dump switches to the alternate buffer
+        // with the 8-bit CSI `?1047h`, and switches back with `?1047l` when the
+        // alternate buffer is no longer active but a cursor was once saved there
+        // (which `vim`/`less`/`htop`/git pager all do). So an *unpaired* `?1047h`
+        // means "on alt now"; a `?1047h`+`?1047l` pair means "exited alt, with a
+        // lingering saved context" and must NOT keyframe - otherwise every
+        // common TUI would re-inject a full-screen redraw into its scrollback
+        // after quitting. A normal scrolling shell produces neither sequence.
+        if !dump.contains("\u{9b}?1047h") || dump.contains("\u{9b}?1047l") {
+            return None;
+        }
+        // avt uses the 8-bit CSI (U+009B); rewrite to the 7-bit `ESC [` form
+        // that every terminal and xterm.js accept.
+        Some(dump.replace('\u{9b}', "\x1b[").into_bytes())
+    }
+
+    fn apply_resize(&mut self, size: TermSize) {
+        let cols = usize::from(size.cols.max(1));
+        let rows = usize::from(size.rows.max(1));
+        if cols != self.cols || rows != self.rows {
+            self.vt.resize(cols, rows);
+            self.cols = cols;
+            self.rows = rows;
+            // Force a fresh keyframe so the stored keyframe matches the new
+            // size announced to viewers.
+            self.frames_since = FRAMES_PER_KEYFRAME;
+        }
+    }
+
+    /// Feed raw bytes to avt, which consumes `&str`. Terminal output may split
+    /// a multibyte char across frames, so a valid UTF-8 prefix is fed now and
+    /// an incomplete trailing sequence is carried; genuinely invalid bytes are
+    /// skipped (xterm renders those as replacement chars too).
+    fn feed_bytes(&mut self, data: &[u8]) {
+        let mut buf = std::mem::take(&mut self.carry);
+        buf.extend_from_slice(data);
+        let mut from = 0;
+        loop {
+            match std::str::from_utf8(&buf[from..]) {
+                Ok(s) => {
+                    if !s.is_empty() {
+                        self.vt.feed_str(s);
+                    }
+                    from = buf.len();
+                    break;
+                }
+                Err(e) => {
+                    let valid = e.valid_up_to();
+                    if valid > 0 {
+                        // `valid_up_to` guarantees this slice is valid UTF-8.
+                        if let Ok(s) = std::str::from_utf8(&buf[from..from + valid]) {
+                            self.vt.feed_str(s);
+                        }
+                    }
+                    match e.error_len() {
+                        // Incomplete trailing sequence: carry the remainder.
+                        None => {
+                            from += valid;
+                            break;
+                        }
+                        // Invalid bytes: skip them and keep decoding.
+                        Some(n) => from += valid + n,
+                    }
+                }
+            }
+        }
+        self.carry = buf[from..].to_vec();
+        if self.carry.len() > MAX_CARRY {
+            self.carry.clear();
+        }
+    }
+}

--- a/src/cli/ws.rs
+++ b/src/cli/ws.rs
@@ -13,6 +13,7 @@
 //! the room now belongs to another password.
 
 use crate::cli::crypto::Encryptor;
+use crate::cli::screen::Keyframer;
 use crate::protocol::TermSize;
 use serde_json::json;
 use std::collections::VecDeque;
@@ -94,6 +95,10 @@ pub struct Transport {
     /// and reconnect replay all operate on ciphertext - a replayed
     /// record is byte-identical, never re-encrypted (no nonce reuse)
     cipher: Option<Encryptor>,
+    /// Headless terminal emulator over the broadcast stream; periodically
+    /// injects a full-screen redraw so late joiners reconstruct the whole
+    /// screen of a long-running TUI (issue #164).
+    keyframer: Keyframer,
     backoff: Duration,
     /// Do not attempt to reconnect before this instant
     next_attempt: Option<Instant>,
@@ -136,6 +141,7 @@ impl Transport {
             sent_size: None,
             theme,
             cipher,
+            keyframer: Keyframer::new(size),
             backoff: INITIAL_BACKOFF,
             next_attempt: None,
             last_ping: Instant::now(),
@@ -148,33 +154,49 @@ impl Transport {
     /// failures keep data buffered and schedule a reconnect; only
     /// authorization failures surface.
     pub fn send(&mut self, data: &[u8], size: TermSize) -> Result<(), TransportError> {
+        // Feed the emulator the exact bytes being broadcast, then buffer the
+        // data, then (when due) a keyframe AFTER it, so the redraw reflects the
+        // screen as of this frame. The keyframe is an ordinary sealed record:
+        // it rides the same acks/cap/replay path with no protocol change.
+        self.keyframer.feed(data, size);
         if !data.is_empty() {
-            // Sealed here, before buffering: everything downstream
-            // (acks, the cap, replay) counts ciphertext bytes, exactly
-            // what the server sees and acknowledges
-            let data: Bytes = self.cipher.as_ref().map_or_else(
-                || Bytes::copy_from_slice(data),
-                |cipher| cipher.seal(data).into(),
-            );
-            self.buffered_bytes += data.len();
-            self.pending.push_back(data);
-            // Drop the oldest buffered output (acked data is already
-            // gone; the oldest is the front of `unacked`, then `pending`)
-            while self.buffered_bytes > MAX_BUFFERED_BYTES {
-                if let Some(dropped) = self.unacked.pop_front() {
-                    // Already written: its ack may still arrive and must
-                    // not be credited to a later chunk
-                    self.dropped_unacked += dropped.len() as u64;
-                    self.buffered_bytes -= dropped.len();
-                } else if let Some(dropped) = self.pending.pop_front() {
-                    self.buffered_bytes -= dropped.len();
-                } else {
-                    break;
-                }
-            }
+            self.buffer_plaintext(data);
+        }
+        if let Some(keyframe) = self.keyframer.maybe_keyframe() {
+            self.buffer_plaintext(&keyframe);
         }
         self.size = size;
         self.flush()
+    }
+
+    /// Seal a chunk (when encrypting) and queue it for delivery, evicting the
+    /// oldest buffered output if the replay cap is exceeded.
+    ///
+    /// Sealed here, before buffering: everything downstream (acks, the cap,
+    /// replay) counts ciphertext bytes, exactly what the server sees and
+    /// acknowledges. A replayed record is byte-identical, never re-encrypted
+    /// (no nonce reuse).
+    fn buffer_plaintext(&mut self, data: &[u8]) {
+        let sealed: Bytes = self.cipher.as_ref().map_or_else(
+            || Bytes::copy_from_slice(data),
+            |cipher| cipher.seal(data).into(),
+        );
+        self.buffered_bytes += sealed.len();
+        self.pending.push_back(sealed);
+        // Drop the oldest buffered output (acked data is already
+        // gone; the oldest is the front of `unacked`, then `pending`)
+        while self.buffered_bytes > MAX_BUFFERED_BYTES {
+            if let Some(dropped) = self.unacked.pop_front() {
+                // Already written: its ack may still arrive and must
+                // not be credited to a later chunk
+                self.dropped_unacked += dropped.len() as u64;
+                self.buffered_bytes -= dropped.len();
+            } else if let Some(dropped) = self.pending.pop_front() {
+                self.buffered_bytes -= dropped.len();
+            } else {
+                break;
+            }
+        }
     }
 
     /// Idle housekeeping: process acknowledgments, retry delivery of


### PR DESCRIPTION
Fixes #164.

## Problem

A long-running full-screen TUI (dashboard, `htop`, `k9s`, a CI watcher with a spinner) paints the screen once, then emits only small incremental updates. The server keeps a bounded **200-message** replay history (`MessageHistory` / `MAX_HISTORY_MESSAGES`), so within ~tens of seconds the initial full paint is evicted. A **late joiner** then replays only cursor-jump-and-redraw-a-cell frames with no base screen underneath — a mostly blank terminal with a lonely spinner.

No bigger buffer fixes this: the session runs for hours. The fix must reconstruct screen **state**, not store a longer byte log.

## Approach (Phase 1 of #164)

Model the stream like a video codec: periodic **keyframes** (full-screen redraws) plus the existing **deltas**.

- The CLI's `Transport` (which already owns the cipher + reliability buffer) runs a headless terminal emulator (`avt`) over the **exact plaintext bytes it broadcasts**.
- Every ~60 frames, **only while on the alternate screen**, it serializes the current screen (`avt::Vt::dump()`), normalizes 8-bit CSI → `ESC[`, **seals it with the same `Encryptor`**, and enqueues it as an ordinary record.
- The keyframe lands in the server's history like any frame, so a late joiner replays a recent keyframe and reconstructs the whole screen.

### Why this is safe — nothing else changes

- **E2E preserved:** emulation + keyframe generation happen on broadcaster plaintext; the keyframe is just more ciphertext. **Crypto record format, server, and viewer are untouched.**
- **Reconnect-safe:** the keyframe is an ordinary sealed record in the existing replay buffer — it replays byte-identically (no new control frame, no nonce reuse, no ack-accounting change).
- **No scrollback regression:** keyframes fire only for alternate-screen sessions, gated on an **unpaired** `?1047h` in avt's dump. A normal scrolling shell produces no keyframe and keeps its raw-history scrollback. A TUI that *exits* the alt screen (leaving a lingering saved cursor context) is correctly excluded.

## Tests

`e2e/test_keyframe.py` (asserts against the real viewer via xterm.js / raw-WS decryption):

- `test_late_joiner_sees_static_chrome_of_long_running_tui` — broadcast an alt-screen TUI, evict the base (300 single-cell updates), connect a late viewer, assert it renders the static chrome.
- `test_no_keyframes_leak_into_scrollback_after_alt_exit` — a TUI that enters alt, saves a non-home cursor, then exits and scrolls must not get keyframes injected into its scrollback.

Both were written **before** the implementation (RED → GREEN). `make lint` clean; full e2e suite **245 passed**.

## Review

Built with multi-agent review at each stage: two plan reviewers (reliability invariants + simplicity/project-fit), then an adversarial implementation review that caught a **CRITICAL** alt-screen-exit bug (the original gate fired keyframes after a TUI quit, corrupting connected viewers). That was fixed TDD-style — the regression test above reproduces it RED on the buggy gate and passes GREEN on the fix — and confirmed by a follow-up re-review.

## Deferred (tracked in #164)

- **Phase 2** server-side history bounding (`{"reset"}` + sticky base) to lower keyframe frequency — only if measured flicker/bandwidth justifies it.
- Binary-size / high-throughput CPU of feeding every byte through `avt` (release binary ≈ 6 MB; `avt` pulls `bytemuck`/`rgb`/`unicode-width`).
- `avt` pinned to `0.16` (0.18 needs rustc 1.82 > the project's MSRV 1.75).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
