### PR TITLE
ci: bump GitHub Actions off deprecated Node.js 20

### DIFF
--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -28,7 +28,7 @@ jobs:
         run: cargo build --release
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.2.0
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -37,7 +37,7 @@ jobs:
         run: cargo build --release
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.2.0
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -63,7 +63,7 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Upload bare binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: target/${{ matrix.target }}/release/${{ matrix.binary }}
@@ -97,7 +97,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -113,25 +113,25 @@ jobs:
 
       # Download all bare binaries from Pass 1
       - name: Download Linux bare binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bare-linux-x86_64
           path: binaries-temp/linux
 
       - name: Download Windows bare binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bare-windows-x86_64
           path: binaries-temp/windows
 
       - name: Download macOS Intel bare binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bare-macos-x86_64
           path: binaries-temp/macos-intel
 
       - name: Download macOS ARM bare binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bare-macos-aarch64
           path: binaries-temp/macos-arm
@@ -161,7 +161,7 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }} --features embed-binaries
 
       - name: Upload embedded binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: target/${{ matrix.target }}/release/${{ matrix.binary }}
@@ -177,10 +177,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download Linux embedded binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: shellshare-linux-x86_64
           path: .
@@ -189,14 +189,14 @@ jobs:
         run: chmod +x shellshare
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.release
@@ -216,25 +216,25 @@ jobs:
 
     steps:
       - name: Download Linux binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: shellshare-linux-x86_64
           path: release/linux
 
       - name: Download Windows binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: shellshare-windows-x86_64
           path: release/windows
 
       - name: Download macOS Intel binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: shellshare-macos-x86_64
           path: release/macos-intel
 
       - name: Download macOS ARM binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: shellshare-macos-aarch64
           path: release/macos-arm
@@ -250,7 +250,7 @@ jobs:
           ls -la assets/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             assets/shellshare-linux-x86_64
@@ -272,10 +272,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
@@ -285,7 +285,7 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Download embedded binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: 'shellshare-*'
           path: npm-binaries


### PR DESCRIPTION
## What

GitHub [deprecated the Node.js 20 runtime](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) for Actions — our runs are currently being force-migrated to Node 24 with a warning annotation on every job. This bumps each flagged action to its latest major, all of which default to the Node 24 runtime, clearing the deprecation.

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | **v7** |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/download-artifact` | v4 | **v8** |
| `actions/setup-node` | v4 | **v6** |
| `astral-sh/setup-uv` | v5 | **v8.2.0** |
| `docker/login-action` | v3 | **v4** |
| `docker/build-push-action` | v5 | **v7** |
| `softprops/action-gh-release` | v2 | **v3** |

`Swatinem/rust-cache` and `dtolnay/rust-toolchain` were **not** flagged (already on Node 24), so they're left untouched.

> [!NOTE]
> `astral-sh/setup-uv` is pinned to a full version (`v8.2.0`) rather than a floating `@v8`. Its v8.0.0 release [removed the workflow that maintains floating major/minor tags](https://github.com/astral-sh/setup-uv/releases/tag/v8.0.0), so `@v8` doesn't resolve — only `v8.x.y` tags exist. Every other action keeps its floating major tag.

## Why these are safe across the major jumps

I checked the breaking-change notes for every major crossed, against how we actually use each action:

- **download-artifact v4→v8** — the v5 breaking change only affects downloads *by ID*; we download by `name` and by `pattern`. The multi-artifact layout `prepare-packages.js` depends on (one subdir per artifact) is unchanged. v8 makes a download hash mismatch *error* by default — a safety win, no spurious failures on hosted runners.
- **upload-artifact v4→v7** — v7's direct (unzipped) upload is opt-in via `archive: false`; the default still zips, so nothing changes for us. v6 is the first major to default to Node 24.
- **setup-node v4→v6** — v5 added automatic caching, but only when a root `package.json` has a `packageManager` field. This repo has no root `package.json` (the npm package lives under `npm/`), so the cache step never triggers.
- **setup-uv v5→v8.2.0** — v6 removed `pyproject-file`/`uv-file` and made venv activation opt-in; we use a bare `astral-sh/setup-uv` with no inputs, so none of that applies. v7 is the first major to default to Node 24.
- **docker/login-action v3→v4, docker/build-push-action v5→v7, action-gh-release v2→v3** — same inputs we already pass; the only removed envs/inputs are ones we don't set.

## Verification

The e2e workflows (which use `checkout` + `setup-uv`) run on this PR and exercise those bumped versions on Linux, macOS, and Windows. The release-only actions (artifacts, docker, setup-node, gh-release) run on the next `v*` tag; I confirmed every floating major tag used here resolves on the remote, so none will fail to download at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)