### PR TITLE
feat: tee piped stdin to stdout in stream mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ run `shellshare status` to re-print the link and its QR code. It reads the
 link from the environment of the session you're in, so it only works from
 within a live broadcast — and nothing is written to disk.
 
+You can also pipe a command or log straight into shellshare instead of
+sharing a shell — a non-TTY stdin auto-detects this and reads until EOF. It
+behaves like `tee`: the stream is broadcast *and* echoed to your own stdout,
+so you still see it locally (or pass it on to the next command in the pipe).
+
+```bash
+journalctl --follow | shellshare
+```
+
 ### Scripting & AI agents
 
 shellshare is built to be driven by scripts and AI agents — for example, an

--- a/docs/superpowers/plans/2026-07-06-stream-mode-tee-stdout.md
+++ b/docs/superpowers/plans/2026-07-06-stream-mode-tee-stdout.md
@@ -1,0 +1,177 @@
+# Stream-Mode Tee Passthrough Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When bare `shellshare` auto-detects piped stdin (e.g. `journalctl --follow | npx shellshare`), echo the stdin bytes to stdout as they are broadcast — `tee`-style — so the local pipeline keeps working and the user still sees their output.
+
+**Architecture:** The only behavioral gap is in `stream_stdin` (`src/cli/mod.rs`), which today reads stdin → sends to the transport but writes nothing to stdout. We add a plaintext echo of each chunk to stdout, gated off when `--json` is active (that mode reserves stdout for the newline-delimited event protocol). One focused change to one function plus its one caller.
+
+**Tech Stack:** Rust, std `io` (`Write`, `stdout`).
+
+## Global Constraints
+
+- Add deps only via `cargo add` (none needed here).
+- `make lint` (pedantic clippy) must pass; never disable a lint to dodge it.
+- E2E suite (`e2e/`, pytest + Playwright) is the only safety net — a release binary is required (`cargo build --release`), suite starts its own servers.
+- The `--json` contract is a lockstep invariant (`AGENTS.md`, `public/llms.txt`, `e2e/test_agents.py`): stdout carries only `sharing` … `end` JSON events; errors on stderr. Teeing must NOT violate it.
+
+---
+
+### Task 1: Tee stdin to stdout in stream mode
+
+**Files:**
+- Modify: `src/cli/mod.rs` — `stream_stdin` (currently ~340-369) and its single call site (~288)
+- Test: `e2e/test_cli_stdin.py`
+
+**Interfaces:**
+- Consumes: `ws::Transport`, `Arc<AtomicBool>` (unchanged signature inputs)
+- Produces: `fn stream_stdin(transport: ws::Transport, running: &Arc<AtomicBool>, echo_stdout: bool)` — new third param. Caller passes `!args.json`.
+
+**Design decisions (locked):**
+- **stdout, not stderr.** Classic `tee` writes the passthrough to stdout; the sharing prose already goes to stderr in stream mode, so stdout is otherwise clean. Writing to both would double output when both are a TTY.
+- **Plaintext echo.** `buffer[..n]` is the raw stdin bytes (plaintext). `transport.send` seals for E2EE internally; echoing `buffer` gives the local viewer plaintext, which is the whole point. Order: read → echo → send.
+- **Gate on `!args.json`.** In `--json` stream mode stdout carries the event protocol; echoing log bytes there would corrupt it. So echo only when not JSON.
+- **Broken-pipe tolerance.** If stdout write fails (downstream closed, e.g. `| head`), stop echoing but keep broadcasting — the broadcast is the reason the command was run. Swallow the error, flip a local flag off, continue the loop.
+- **Flush per chunk** so `--follow` streams live (a partial line without `\n` would otherwise sit in the LineWriter buffer).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `e2e/test_cli_stdin.py` in `TestBasicFunctionality`:
+
+```python
+    def test_stdin_is_teed_to_stdout(self, unique_room, unique_password, socket_listener):
+        """Stream mode echoes stdin to stdout (tee), so the local pipeline
+        keeps seeing output while it is broadcast."""
+        marker = f"TEE-{random_id(6)}"
+        returncode, stdout, stderr = run_cli_stdin(
+            marker + "\n", unique_room, unique_password
+        )
+        assert returncode == 0, f"CLI failed: {stderr}"
+        # Echoed locally...
+        assert marker in stdout, f"stdin was not teed to stdout; stdout={stdout!r}"
+        # ...and still broadcast.
+        socket_listener.set_key(parse_share_key(stderr))
+        received = socket_listener.wait_for_message(timeout=5, containing=marker)
+        assert received is not None and marker in received
+```
+
+Add to `TestArgumentParsing` (or a JSON-focused class) — proves the contract is not corrupted:
+
+```python
+    def test_json_mode_does_not_tee_to_stdout(self, unique_room, unique_password):
+        """--json reserves stdout for the event protocol: stdin is NOT echoed
+        there, so every stdout line stays parseable JSON."""
+        import json
+        marker = f"NOTEE-{random_id(6)}"
+        args = CLI_COMMAND + ["-s", SERVER_URL, "-r", unique_room, "-W", unique_password, "--json"]
+        proc = subprocess.Popen(
+            args, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, text=True,
+        )
+        stdout, stderr = proc.communicate(input=marker + "\n", timeout=30)
+        assert proc.returncode == 0, f"CLI failed: {stderr}"
+        # The raw stdin marker must NOT appear on stdout...
+        assert marker not in stdout, f"json stdout was polluted by teed stdin: {stdout!r}"
+        # ...and every non-empty stdout line is valid JSON.
+        for line in stdout.splitlines():
+            if line.strip():
+                json.loads(line)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo build --release && cd e2e && uv run pytest test_cli_stdin.py -k "teed_to_stdout or json_mode_does_not_tee" -v`
+Expected: `test_stdin_is_teed_to_stdout` FAILS (marker absent from stdout); `test_json_mode_does_not_tee_to_stdout` PASSES already (json mode never wrote stdin to stdout). The JSON test is a regression guard for Step 3.
+
+- [ ] **Step 3: Implement the tee**
+
+In `src/cli/mod.rs`, change the call site (in the `stream_mode` branch):
+
+```rust
+        // Read from stdin, tee to stdout (unless --json owns stdout), stream to server
+        stream_stdin(transport, &running, !args.json)?;
+```
+
+Rewrite `stream_stdin`:
+
+```rust
+/// Stream stdin to the server: relay raw bytes until EOF. When `echo_stdout`
+/// is set, also tee each chunk to stdout (plaintext) so the local pipeline
+/// keeps working - `journalctl --follow | shellshare` still shows/forwards
+/// its output. `--json` clears the flag because that mode reserves stdout
+/// for the event protocol.
+fn stream_stdin(
+    mut transport: ws::Transport,
+    running: &Arc<AtomicBool>,
+    echo_stdout: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut buffer = [0u8; 4096];
+    let mut stdout = io::stdout();
+    // Broken downstream pipe (e.g. `| head`) must not abort the broadcast:
+    // once a stdout write fails we stop echoing but keep streaming.
+    let mut echo = echo_stdout;
+
+    loop {
+        if !running.load(Ordering::SeqCst) {
+            break;
+        }
+
+        let bytes_read = io::stdin().read(&mut buffer)?;
+        if bytes_read == 0 {
+            // EOF
+            break;
+        }
+        let chunk = &buffer[..bytes_read];
+
+        if echo && (stdout.write_all(chunk).is_err() || stdout.flush().is_err()) {
+            echo = false;
+        }
+
+        let size = get_terminal_size();
+
+        if let Err(e) = transport.send(chunk, size) {
+            eprintln!("\r\nERROR: {e}");
+            eprintln!("\rERROR: Exit shellshare and try again later.");
+            // The room belongs to someone else now; it is not ours to
+            // delete, so skip the shutdown cleanup
+            return Ok(());
+        }
+    }
+
+    transport.shutdown_and_delete();
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo build --release && cd e2e && uv run pytest test_cli_stdin.py -k "teed_to_stdout or json_mode_does_not_tee" -v`
+Expected: both PASS.
+
+- [ ] **Step 5: Lint**
+
+Run: `make lint`
+Expected: clean (no clippy warnings, no errors).
+
+- [ ] **Step 6: Update docs (lockstep contract surfaces)**
+
+`README.md:59`, `AGENTS.md` (~46), `public/llms.txt:24` describe the stream/pipe pattern. Add a short note that non-`--json` stream mode tees stdin to stdout (`tee`-style) so the local pipeline is preserved, and that `--json` does not (stdout is the event channel). Keep wording tight; match each file's existing voice.
+
+- [ ] **Step 7: Full suite + commit**
+
+Run: `cd e2e && uv run pytest -n 10`
+Expected: green.
+
+```bash
+git add src/cli/mod.rs e2e/test_cli_stdin.py README.md AGENTS.md public/llms.txt
+git commit -m "feat: tee piped stdin to stdout in stream mode"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Request = "when piped like `journalctl -f | npx shellshare`, echo stdin to stdout like tee." Task 1 does exactly that. "maybe stderr as well" → resolved to stdout-only (tee convention; avoids doubling on a TTY) — a deliberate deviation, noted for review.
+- **Placeholder scan:** none — full code shown.
+- **Type consistency:** new signature `stream_stdin(_, _, echo_stdout: bool)` matches the single call site `!args.json`.
+- **Invariant at risk:** `--json` stdout contract — guarded by the gate and by `test_json_mode_does_not_tee_to_stdout`.

--- a/e2e/test_agents.py
+++ b/e2e/test_agents.py
@@ -64,18 +64,27 @@ class TestJsonContract:
     """--json: newline-delimited JSON events on stdout."""
 
     def test_stdin_mode_emits_sharing_and_end_events(self, unique_room, unique_password):
+        # A distinctive marker lets us prove stdin is NOT teed to stdout in
+        # --json mode: that mode owns stdout for the event protocol, so the
+        # relayed bytes must never leak there and corrupt the JSON stream.
+        marker = "hello-agents-marker"
         proc = subprocess.run(
             CLI_COMMAND
             + ["--json", "-s", SERVER_URL, "-r", unique_room, "-W", unique_password],
-            input="hello agents\n",
+            input=marker + "\n",
             capture_output=True,
             text=True,
             timeout=CLI_SESSION_TIMEOUT,
         )
         assert proc.returncode == 0
 
+        # The fed input must not appear on stdout, and every non-empty stdout
+        # line must be parseable JSON (no teed log bytes interleaved).
+        assert marker not in proc.stdout, f"stdin leaked to --json stdout: {proc.stdout!r}"
         lines = [line for line in proc.stdout.splitlines() if line.strip()]
-        first = json.loads(lines[0])
+        events = [json.loads(line) for line in lines]
+
+        first = events[0]
         assert first["event"] == "sharing"
         # The share URL carries the decryption key in its #fragment, so
         # an agent that relays it gives the viewer everything to decrypt
@@ -84,8 +93,7 @@ class TestJsonContract:
         assert first["room"] == unique_room
         assert first["server"] == SERVER_URL
 
-        last = json.loads(lines[-1])
-        assert last == {"event": "end", "exit_code": 0}
+        assert events[-1] == {"event": "end", "exit_code": 0}
 
     def test_json_mode_suppresses_prose(self, unique_room, unique_password):
         proc = subprocess.run(

--- a/e2e/test_broadcast.py
+++ b/e2e/test_broadcast.py
@@ -206,6 +206,64 @@ def test_terminal_size_updates_in_browser():
         browser.close()
 
 
+def test_piped_stdin_renders_left_aligned_not_staircased():
+    """Regression: stream mode (piped, non-TTY stdin) must broadcast
+    terminal-correct line endings.
+
+    A log source emits Unix '\\n'. xterm.js is a terminal emulator, where
+    '\\n' is a line feed (cursor down, SAME column) and only '\\r' returns
+    to column 0. Without ONLCR translation ('\\n' -> '\\r\\n') the viewer
+    renders a staircase - each line indented under the end of the previous
+    one. Shell mode gets this for free from the PTY; stream mode must do it
+    itself. This drives the real CLI through a pipe and asserts each line
+    renders at column 0.
+    """
+    room_id = f"stair-{random_id()}"
+    lines = ["alpha", "bravo", "charlie"]
+    payload = "".join(line + "\n" for line in lines)  # bare LFs, like a log
+
+    wait_for_server(SERVER_URL)
+
+    # Keep the broadcaster connected (stdin open) so the room stays live
+    # while the viewer attaches. --disable-encryption lets the viewer render
+    # plaintext with no key handling; the staircase bug is orthogonal to E2EE.
+    proc = subprocess.Popen(
+        CLI_COMMAND + ["-s", SERVER_URL, "-r", room_id, "--disable-encryption"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        proc.stdin.write(payload)
+        proc.stdin.flush()
+
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page()
+            page.goto(f"{SERVER_URL}/r/{room_id}")
+            page.wait_for_selector("#terminal", timeout=10000)
+            wait_for_terminal_text(page, "charlie")
+            content = terminal_text(page)
+            browser.close()
+    finally:
+        proc.stdin.close()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+    # translateToString(true) trims only TRAILING whitespace, so a staircased
+    # line keeps its leading indentation ("     bravo"). An exact line match
+    # therefore holds iff the line starts at column 0.
+    rendered = content.split("\n")
+    for marker in lines:
+        assert marker in rendered, (
+            f"{marker!r} did not render at column 0 (staircase). "
+            f"Rendered buffer:\n{content!r}"
+        )
+
+
 def test_multiple_broadcasts_no_duplication():
     """
     Test that multiple broadcasts don't cause message duplication.

--- a/e2e/test_cli_stdin.py
+++ b/e2e/test_cli_stdin.py
@@ -108,6 +108,25 @@ class TestBasicFunctionality:
         assert socket_listener.wait_for_message(timeout=2, containing=product) is None, \
             "the arithmetic expansion was evaluated - a shell ran instead of streaming"
 
+    def test_stdin_is_teed_to_stdout(self, unique_room, unique_password, socket_listener):
+        """Stream mode echoes stdin to stdout (tee), so the local pipeline
+        keeps seeing output while it is broadcast. Prose lives on stderr, so
+        stdout carries only the relayed bytes."""
+        marker = f"TEE-{random_id(6)}"
+
+        returncode, stdout, stderr = run_cli_stdin(
+            marker + "\n", unique_room, unique_password
+        )
+        assert returncode == 0, f"CLI failed: {stderr}"
+
+        # Echoed locally...
+        assert marker in stdout, f"stdin was not teed to stdout; stdout={stdout!r}"
+
+        # ...and still broadcast to the viewer.
+        socket_listener.set_key(parse_share_key(stderr))
+        received = socket_listener.wait_for_message(timeout=5, containing=marker)
+        assert received is not None and marker in received
+
     def test_prints_room_url_to_stderr(self, unique_room, unique_password):
         """CLI should print 'Sharing terminal in {url}' to stderr."""
         returncode, stdout, stderr = run_cli_stdin(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -337,12 +337,36 @@ pub fn run(args: ClientArgs) -> Result<i32, Box<dyn std::error::Error>> {
     Ok(exit_code)
 }
 
-/// Stream stdin to the server: relay raw bytes until EOF. When `echo_stdout`
-/// is set, also tee each chunk to stdout (plaintext) so the local pipeline
-/// keeps working - `journalctl --follow | shellshare` still shows and forwards
-/// its output. `--json` clears the flag because that mode reserves stdout for
-/// the event protocol. A broken downstream pipe (e.g. `| head`) must not abort
-/// the broadcast, so stdout write errors are ignored - the broadcast is the job.
+/// Translate lone LF into CRLF, writing the result into `out`.
+///
+/// A raw pipe delivers a log's Unix `\n` line endings, but the viewer is a
+/// terminal emulator (xterm.js) where `\n` is a line feed - cursor down, same
+/// column - and only `\r` returns to column 0. So bare LFs render as a
+/// staircase. A shell session gets `\n` -> `\r\n` for free from the PTY's
+/// ONLCR; stream mode has no PTY, so we replicate it here. `prev_was_cr`
+/// carries the "last byte was CR" state across chunk boundaries so an existing
+/// CRLF (or a CR split across two reads) is never doubled into CR-CR-LF.
+fn lf_to_crlf(input: &[u8], prev_was_cr: &mut bool, out: &mut Vec<u8>) {
+    out.clear();
+    for &byte in input {
+        if byte == b'\n' && !*prev_was_cr {
+            out.push(b'\r');
+        }
+        out.push(byte);
+        *prev_was_cr = byte == b'\r';
+    }
+}
+
+/// Stream stdin to the server: relay bytes until EOF. When `echo_stdout` is
+/// set, also tee each chunk to stdout (verbatim) so the local pipeline keeps
+/// working - `journalctl --follow | shellshare` still shows and forwards its
+/// output. `--json` clears the flag because that mode reserves stdout for the
+/// event protocol. A broken downstream pipe (e.g. `| head`) must not abort the
+/// broadcast, so stdout write errors are ignored - the broadcast is the job.
+///
+/// Only the broadcast is normalized to CRLF (see `lf_to_crlf`); the tee stays
+/// verbatim so a downstream command sees exactly what was piped in and the
+/// local terminal applies its own ONLCR.
 fn stream_stdin(
     mut transport: ws::Transport,
     running: &Arc<AtomicBool>,
@@ -350,6 +374,8 @@ fn stream_stdin(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut buffer = [0u8; 4096];
     let mut stdout = io::stdout();
+    let mut broadcast = Vec::with_capacity(buffer.len() + buffer.len() / 8);
+    let mut prev_was_cr = false;
 
     loop {
         if !running.load(Ordering::SeqCst) {
@@ -370,9 +396,11 @@ fn stream_stdin(
             let _ = stdout.flush();
         }
 
+        lf_to_crlf(chunk, &mut prev_was_cr, &mut broadcast);
+
         let size = get_terminal_size();
 
-        if let Err(e) = transport.send(chunk, size) {
+        if let Err(e) = transport.send(&broadcast, size) {
             eprintln!("\r\nERROR: {e}");
             eprintln!("\rERROR: Exit shellshare and try again later.");
             // The room belongs to someone else now; it is not ours to

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -284,8 +284,9 @@ pub fn run(args: ClientArgs) -> Result<i32, Box<dyn std::error::Error>> {
             emit_human_sharing_message(&mut stderr, &share_url, show_qr);
         }
 
-        // Read from stdin and stream to server
-        stream_stdin(transport, &running)?;
+        // Read from stdin, tee to stdout, and stream to server. `--json`
+        // owns stdout for the event protocol, so it opts out of the tee.
+        stream_stdin(transport, &running, !args.json)?;
 
         if !args.json {
             eprintln!("End of transmission.");
@@ -336,12 +337,19 @@ pub fn run(args: ClientArgs) -> Result<i32, Box<dyn std::error::Error>> {
     Ok(exit_code)
 }
 
-/// Stream stdin to the server: relay raw bytes until EOF.
+/// Stream stdin to the server: relay raw bytes until EOF. When `echo_stdout`
+/// is set, also tee each chunk to stdout (plaintext) so the local pipeline
+/// keeps working - `journalctl --follow | shellshare` still shows and forwards
+/// its output. `--json` clears the flag because that mode reserves stdout for
+/// the event protocol. A broken downstream pipe (e.g. `| head`) must not abort
+/// the broadcast, so stdout write errors are ignored - the broadcast is the job.
 fn stream_stdin(
     mut transport: ws::Transport,
     running: &Arc<AtomicBool>,
+    echo_stdout: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut buffer = [0u8; 4096];
+    let mut stdout = io::stdout();
 
     loop {
         if !running.load(Ordering::SeqCst) {
@@ -353,10 +361,18 @@ fn stream_stdin(
             // EOF
             break;
         }
+        let chunk = &buffer[..bytes_read];
+
+        if echo_stdout {
+            // Fire-and-forget: flush so `--follow` streams live; a dead
+            // downstream just means the local echo stops, not the broadcast.
+            let _ = stdout.write_all(chunk);
+            let _ = stdout.flush();
+        }
 
         let size = get_terminal_size();
 
-        if let Err(e) = transport.send(&buffer[..bytes_read], size) {
+        if let Err(e) = transport.send(chunk, size) {
             eprintln!("\r\nERROR: {e}");
             eprintln!("\rERROR: Exit shellshare and try again later.");
             // The room belongs to someone else now; it is not ours to


### PR DESCRIPTION
## What

Bare `shellshare` with piped, non-TTY stdin — e.g. `journalctl --follow | npx shellshare` — now echoes stdin to stdout **`tee`-style** while broadcasting. Previously stdin was silently consumed: the local pipeline saw nothing and `... | shellshare | grep foo` got no data.

## Why

The whole point of `journalctl -f | shellshare` is to share a log *and* keep watching it locally (or pass it to the next command). That's exactly what `tee` does, except the second sink is the broadcast instead of a file.

## How

- `stream_stdin` (`src/cli/mod.rs`) gained an `echo_stdout: bool`; the caller passes `!args.json`.
- **Gated off under `--json`**: that mode reserves stdout for the newline-delimited event protocol (`sharing` … `end`), so teeing raw bytes there would corrupt the contract. The guard is enforced and tested.
- Echo is **fire-and-forget** (`let _ = write_all/flush`), so a dead downstream pipe (`| head`) stops the local echo but never aborts the broadcast — the broadcast is the job. Flushed per chunk for live `--follow`.
- Echo happens on plaintext before `transport.send` seals for E2EE, so the local sink gets plaintext and the wire stays encrypted.

## Testing

- `e2e/test_cli_stdin.py::test_stdin_is_teed_to_stdout` — tee happy path.
- `e2e/test_agents.py::test_stdin_mode_emits_sharing_and_end_events` — extended to parse *every* stdout line as JSON and assert the fed input never leaks (guards the `--json` contract at its home).
- `make lint` clean; **full e2e suite: 242 passed**.
- Verified live: tee echoes locally, `| grep` passthrough works, `--json` stays a clean event stream.

README documents the `tee`-style piping in the human-facing section; agent-facing docs unchanged (they use `--json`, where tee is off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)