### PR TITLE
docs(agent): normalize CRLF to LF in the reference decoders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,9 @@ Both are a sequence of self-delimiting records:
 `[u32 BE N][12-byte nonce][ciphertext || 16-byte GCM tag]`, where
 `N = 12 + len(ciphertext || tag)`, AES-256-GCM, key = the 64 hex chars
 after `#`. Concatenate the decrypted plaintexts to rebuild the terminal
-stream; strip ANSI escapes for a clean log.
+stream; strip ANSI escapes and fold CRLF line endings to LF for a clean
+log (the stream is terminal output, so lines end in CRLF - as a PTY
+produces - regardless of how the broadcast was fed).
 
 Ready-to-run reference decoders (Node, zero install) are in
 [`agent/`](agent/): `decrypt.mjs` (snapshot) and `follow.mjs` (live, with

--- a/agent/decrypt.mjs
+++ b/agent/decrypt.mjs
@@ -61,5 +61,6 @@ while (o + 4 <= buf.length) {
 const plain = Buffer.concat(parts)
   .toString('utf8')
   .replace(/\x1b\[[0-9;?]*[A-Za-z]/g, '') // strip CSI escapes
-  .replace(/\x1b\][^\x07]*\x07/g, ''); // strip OSC escapes
+  .replace(/\x1b\][^\x07]*\x07/g, '') // strip OSC escapes
+  .replace(/\r\n/g, '\n'); // fold terminal CRLF to LF for a clean log
 process.stdout.write(plain);

--- a/agent/follow.mjs
+++ b/agent/follow.mjs
@@ -53,7 +53,9 @@ const timeBound = has('seconds') ? Number(val('seconds', 0)) : has('idle') || ha
 const idleSecs = has('idle') ? Number(val('idle', 0)) : 0;
 const until = has('until') ? new RegExp(val('until', '')) : null;
 
-const stripAnsi = (s) => s.replace(/\x1b\[[0-9;?]*[A-Za-z]/g, '').replace(/\x1b\][^\x07]*\x07/g, '');
+// Clean the terminal stream for a log: strip ANSI escapes and fold the
+// terminal's CRLF line endings to plain LF.
+const cleanLog = (s) => s.replace(/\x1b\[[0-9;?]*[A-Za-z]/g, '').replace(/\x1b\][^\x07]*\x07/g, '').replace(/\r\n/g, '\n');
 
 let done = false;
 const finish = (why, code = 0) => {
@@ -102,7 +104,7 @@ ws.onmessage = (ev) => {
       finish('decryption failed - wrong key?', 1);
       return;
     }
-    const clean = stripAnsi(txt);
+    const clean = cleanLog(txt);
     process.stdout.write(clean);
     acc += clean;
     if (until && until.test(acc)) {

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -60,7 +60,7 @@ function decodeRecords(keyHex, buf) {
     d.setAuthTag(body.subarray(-16));
     text += Buffer.concat([d.update(body.subarray(0, -16)), d.final()]).toString('utf8');
   }
-  const clean = text.replace(/\x1b\[[0-9;?]*[A-Za-z]/g, '').replace(/\x1b\][^\x07]*\x07/g, ''); // strip ANSI
+  const clean = text.replace(/\x1b\[[0-9;?]*[A-Za-z]/g, '').replace(/\x1b\][^\x07]*\x07/g, '').replace(/\r\n/g, '\n'); // strip ANSI + fold CRLF to LF
   return { text: clean, consumed: o };
 }
 


### PR DESCRIPTION
## What

The reference agent decoders (`agent/decrypt.mjs`, `agent/follow.mjs`) and the decode recipes in `AGENTS.md` / `public/llms.txt` now fold `\r\n` → `\n`, right next to where they already strip ANSI escapes.

## Why

A shellshare broadcast is a **terminal stream**, so lines end in CRLF:
- `shellshare exec` and interactive shell broadcasts are cooked by a PTY (ONLCR), which emits `\r\n` — this is true **today**, independent of #169.
- Piped broadcasts (`journalctl -f | shellshare`) are normalized to match in #169, so the browser viewer renders correctly instead of a staircase.

An agent consuming that stream via `GET /r/:room.bin` (or the viewer WebSocket) for a **clean log** wants plain `\n`, not a trailing `\r` on every line. Folding CRLF is the same class of consumer-side cleanup the decoders already do for ANSI escapes — so it belongs in the same place. This gives agents a **mode-independent** `\n` log (before, `exec`/shell gave CRLF and piped gave LF — inconsistent).

Terminal correctness of the stored/broadcast stream is preserved (browsers still get a real terminal render); only the log-consumer decoders normalize.

## Changes
- `agent/decrypt.mjs` — append `.replace(/\r\n/g, '\n')` to the cleanup chain.
- `agent/follow.mjs` — same; renamed `stripAnsi` → `cleanLog` since it now does both.
- `public/llms.txt`, `AGENTS.md` — decode recipe updated to match.

## Testing

Verified end-to-end: drove a live broadcast containing CRLF + ANSI color, fetched `/r/:room.bin`, and ran the actual `decrypt.mjs` — output was exactly `alpha\nbravo\nRED\ncharlie\n` (pure LF, ANSI stripped). Both `.mjs` files pass `node --check`.

Note: these are reference/example decoders with no existing e2e coverage (the agent-read tests decode via the test helpers, not the `.mjs` files), and the e2e suite runs on the Rust binary + Playwright without shelling out to `node`. Adding a node-subprocess test for a one-line regex would introduce a new CI dependency disproportionate to the change, so this was verified manually instead.

## Relationship to #169
Independent and mergeable on its own (exec/shell broadcasts are already CRLF today). It complements #169: that PR makes the broadcast terminal-correct for browsers; this one keeps the agent-facing log clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)