### PR TITLE
Bound what a room can cost now that rooms outlive their broadcaster

### DIFF
--- a/e2e/test_room_cleanup.py
+++ b/e2e/test_room_cleanup.py
@@ -86,14 +86,16 @@ class TestRoomTtlCleanup:
             watched_and_polled_but_gone, timeout=10, interval=0.5
         ), "room outlived its TTL while only being watched and polled"
 
-    def test_an_attached_broadcaster_is_never_evicted(self, dedicated_server):
-        """A live broadcast keeps its room, however quiet it goes.
+    def test_an_attached_broadcaster_outlives_a_short_ttl(self, dedicated_server):
+        """A live broadcast is not evicted by a TTL shorter than its pings.
 
         Eviction goes by activity, which a live broadcast does not
         necessarily produce - a quiet producer says nothing for long
         stretches, and the keepalive pings that refresh a room only fire
-        every 30s, so a shorter TTL outruns them. An attached connection
-        is the room's liveness, so it is never swept.
+        every 30s. An attached broadcaster therefore gets a floor on its
+        room's lifetime. It is a floor, not an exemption: the room still
+        ages out, which is what keeps a leaked attach count from pinning
+        it forever.
         """
         server = dedicated_server("--cleanup-interval", 1, "--room-ttl", 2)
         room = f"ttl-{random_id()}"

--- a/e2e/test_ws.py
+++ b/e2e/test_ws.py
@@ -146,6 +146,7 @@ class TestWsIngest:
         what a late joiner is there to see.
         """
         newest = f"NEWEST-{random_id()}"
+        keeper = f"KEEPER-{random_id()}"
         ws = ws_connect_room(SERVER_URL, unique_room, unique_password)
         try:
             # 64KB is what the CLI actually coalesces up to (MAX_BATCH), and
@@ -154,6 +155,13 @@ class TestWsIngest:
             for _ in range(160):
                 ws.send_binary(b"x" * (64 * 1024))
                 ws.recv()  # ack
+            # Comfortably inside the budget, so it must still be there:
+            # without this a "keep only the newest chunk" implementation
+            # would satisfy the size assertion below
+            ws.send_binary(keeper.encode())
+            ws.recv()
+            ws.send_binary(b"y" * (64 * 1024))
+            ws.recv()
             ws.send_binary(newest.encode())
             ws.recv()
         finally:
@@ -162,6 +170,9 @@ class TestWsIngest:
         resp = requests.get(f"{SERVER_URL}/r/{unique_room}.bin")
         assert resp.status_code == 200
         assert newest.encode() in resp.content, "the newest output was trimmed away"
+        assert keeper.encode() in resp.content, (
+            "history kept only the tail; earlier in-budget output was dropped"
+        )
         # The guarantee is the budget plus at most one final frame
         assert len(resp.content) <= 4 * 1024 * 1024 + 128 * 1024, (
             f"history kept {len(resp.content)} bytes of a 10MB broadcast; "

--- a/e2e/test_ws.py
+++ b/e2e/test_ws.py
@@ -33,6 +33,7 @@ from conftest import (
     parse_share_key,
     random_id,
     wait_for_content,
+    poll_until,
     wait_for_server,
     ws_connect_room,
 )
@@ -149,8 +150,9 @@ class TestWsIngest:
         keeper = f"KEEPER-{random_id()}"
         ws = ws_connect_room(SERVER_URL, unique_room, unique_password)
         try:
-            # 69,631 bytes is the CLI's real maximum frame: MAX_BATCH is
-            # checked before a 4096-byte read extends the batch. 180 of
+            # 69,631 bytes is the CLI's real maximum of terminal output
+            # per frame: MAX_BATCH is checked before a 4096-byte read
+            # extends the batch. 180 of
             # them stay under the 200-message cap, so only the byte budget
             # can be what trims this
             for _ in range(180):
@@ -205,12 +207,17 @@ class TestWsIngest:
             except Exception:
                 pass
 
+        # Polled rather than read once: the only thing ordering the
+        # server's handling of that frame before this read is the close
+        # handshake, and a close that times out would silently turn this
+        # into a race the unfixed server could win
+        assert poll_until(
+            lambda: b"zzzz" in requests.get(f"{SERVER_URL}/r/{unique_room}.bin").content,
+            timeout=2,
+        ) is False, "an over-cap frame was stored"
         resp = requests.get(f"{SERVER_URL}/r/{unique_room}.bin")
         assert resp.status_code == 200
         assert marker.encode() in resp.content, "the room lost what it had"
-        assert b"zzzz" not in resp.content, (
-            f"an over-cap frame was stored ({len(resp.content)} bytes of history)"
-        )
 
     def test_utf8_sequence_split_across_frames(self, unique_room, unique_password, socket_listener):
         # 'é' is two bytes; send one per frame. Viewers decode the stream,

--- a/e2e/test_ws.py
+++ b/e2e/test_ws.py
@@ -149,18 +149,19 @@ class TestWsIngest:
         keeper = f"KEEPER-{random_id()}"
         ws = ws_connect_room(SERVER_URL, unique_room, unique_password)
         try:
-            # 64KB is what the CLI actually coalesces up to (MAX_BATCH), and
-            # 160 of them stay under the 200-message cap, so only the byte
-            # budget can be what trims this
-            for _ in range(160):
-                ws.send_binary(b"x" * (64 * 1024))
+            # 69,631 bytes is the CLI's real maximum frame: MAX_BATCH is
+            # checked before a 4096-byte read extends the batch. 180 of
+            # them stay under the 200-message cap, so only the byte budget
+            # can be what trims this
+            for _ in range(180):
+                ws.send_binary(b"x" * 69_631)
                 ws.recv()  # ack
             # Comfortably inside the budget, so it must still be there:
             # without this a "keep only the newest chunk" implementation
             # would satisfy the size assertion below
             ws.send_binary(keeper.encode())
             ws.recv()
-            ws.send_binary(b"y" * (64 * 1024))
+            ws.send_binary(b"y" * 69_631)
             ws.recv()
             ws.send_binary(newest.encode())
             ws.recv()
@@ -174,9 +175,41 @@ class TestWsIngest:
             "history kept only the tail; earlier in-budget output was dropped"
         )
         # The guarantee is the budget plus at most one final frame
-        assert len(resp.content) <= 4 * 1024 * 1024 + 128 * 1024, (
-            f"history kept {len(resp.content)} bytes of a 10MB broadcast; "
+        assert len(resp.content) <= 8 * 1024 * 1024 + 69_631, (
+            f"history kept {len(resp.content)} bytes of a 12MB broadcast; "
             "the byte budget is not bounding it"
+        )
+
+    def test_oversized_frame_is_not_stored(self, unique_room, unique_password):
+        """The server caps ingest frames, so one cannot blow the budget.
+
+        The history budget can be overshot by one frame - the newest
+        chunk always survives whatever its size - so the frame cap is
+        what actually closes the ceiling. It must stay at or above the
+        client's own replay-buffer cap: a chunk the client keeps but the
+        server refuses would sit at the head of its buffer, be rewritten
+        on every reconnect, and block everything behind it forever.
+        """
+        marker = f"BEFORE-{random_id()}"
+        ws = ws_connect_room(SERVER_URL, unique_room, unique_password)
+        try:
+            ws.send_binary(marker.encode())
+            ws.recv()  # ack
+            # One byte over the cap. Asserting on what the ROOM holds, not
+            # on which exception the socket raises: a timeout would
+            # satisfy `raises(Exception)` whether or not the cap exists
+            ws.send_binary(b"z" * (1024 * 1024 + 1))
+        finally:
+            try:
+                ws.close()
+            except Exception:
+                pass
+
+        resp = requests.get(f"{SERVER_URL}/r/{unique_room}.bin")
+        assert resp.status_code == 200
+        assert marker.encode() in resp.content, "the room lost what it had"
+        assert b"zzzz" not in resp.content, (
+            f"an over-cap frame was stored ({len(resp.content)} bytes of history)"
         )
 
     def test_utf8_sequence_split_across_frames(self, unique_room, unique_password, socket_listener):

--- a/e2e/test_ws.py
+++ b/e2e/test_ws.py
@@ -21,6 +21,8 @@ from playwright.sync_api import sync_playwright
 
 import os
 
+import requests
+
 from conftest import (
     CLI_COMMAND,
     SERVER_URL,
@@ -32,6 +34,7 @@ from conftest import (
     random_id,
     wait_for_content,
     wait_for_server,
+    ws_connect_room,
 )
 
 
@@ -130,6 +133,40 @@ class TestWsIngest:
         finally:
             late.disconnect()
         assert broadcast_message(SERVER_URL, unique_room, "another-password", "x") == 200
+
+    def test_history_is_bounded_by_bytes_not_just_frames(
+        self, unique_room, unique_password
+    ):
+        """A room's stored history has a memory ceiling.
+
+        Rooms outlive their broadcaster, so the server holds every room
+        broadcast within the TTL. Capping frames alone left the ceiling at
+        frames x 64KB; a byte budget bounds it regardless of how big each
+        frame is. The newest output must survive the trimming - that is
+        what a late joiner is there to see.
+        """
+        newest = f"NEWEST-{random_id()}"
+        ws = ws_connect_room(SERVER_URL, unique_room, unique_password)
+        try:
+            # 64KB is what the CLI actually coalesces up to (MAX_BATCH), and
+            # 160 of them stay under the 200-message cap, so only the byte
+            # budget can be what trims this
+            for _ in range(160):
+                ws.send_binary(b"x" * (64 * 1024))
+                ws.recv()  # ack
+            ws.send_binary(newest.encode())
+            ws.recv()
+        finally:
+            ws.close()
+
+        resp = requests.get(f"{SERVER_URL}/r/{unique_room}.bin")
+        assert resp.status_code == 200
+        assert newest.encode() in resp.content, "the newest output was trimmed away"
+        # The guarantee is the budget plus at most one final frame
+        assert len(resp.content) <= 4 * 1024 * 1024 + 128 * 1024, (
+            f"history kept {len(resp.content)} bytes of a 10MB broadcast; "
+            "the byte budget is not bounding it"
+        )
 
     def test_utf8_sequence_split_across_frames(self, unique_room, unique_password, socket_listener):
         # 'é' is two bytes; send one per frame. Viewers decode the stream,

--- a/e2e/uv.lock
+++ b/e2e/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P14D"
+
 [[package]]
 name = "certifi"
 version = "2026.5.20"

--- a/e2e/uv.lock
+++ b/e2e/uv.lock
@@ -2,10 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P14D"
-
 [[package]]
 name = "certifi"
 version = "2026.5.20"

--- a/src/cli/screen.rs
+++ b/src/cli/screen.rs
@@ -17,8 +17,8 @@ use crate::protocol::TermSize;
 /// Emit a keyframe at most once per this many broadcast frames. Kept well below
 /// the server's history bounds (`MAX_HISTORY_MESSAGES` and `MAX_HISTORY_BYTES`,
 /// `src/server/rooms.rs`) so a recent keyframe survives in the window a late
-/// joiner replays - the byte budget is sized from this number, so moving either
-/// means checking the other. Note this counts *fed frames*, not stored history
+/// joiner replays - the byte budget is derived from this number and the maximum
+/// frame size, so moving any of them means redoing that arithmetic. Note this counts *fed frames*, not stored history
 /// messages - the sender coalesces reads, so one fed frame need not be one
 /// history message; the wide margin absorbs that.
 const FRAMES_PER_KEYFRAME: u32 = 60;

--- a/src/cli/screen.rs
+++ b/src/cli/screen.rs
@@ -15,10 +15,12 @@
 use crate::protocol::TermSize;
 
 /// Emit a keyframe at most once per this many broadcast frames. Kept well below
-/// the server's 200-message history cap (`MAX_HISTORY_MESSAGES`) so a recent
-/// keyframe survives in the window a late joiner replays. Note this counts
-/// *fed frames*, not stored history messages - the sender coalesces reads, so
-/// one fed frame need not be one history message; the wide margin absorbs that.
+/// the server's history bounds (`MAX_HISTORY_MESSAGES` and `MAX_HISTORY_BYTES`,
+/// `src/server/rooms.rs`) so a recent keyframe survives in the window a late
+/// joiner replays - the byte budget is sized from this number, so moving either
+/// means checking the other. Note this counts *fed frames*, not stored history
+/// messages - the sender coalesces reads, so one fed frame need not be one
+/// history message; the wide margin absorbs that.
 const FRAMES_PER_KEYFRAME: u32 = 60;
 
 /// Cap on carried bytes. A valid incomplete UTF-8 tail is at most 3 bytes;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -58,7 +58,13 @@ impl MessageHistory {
     /// The newest chunk always survives, even when it alone exceeds the
     /// byte budget: dropping it would silently discard the very output
     /// being broadcast, and a viewer showing one oversized frame beats a
-    /// viewer showing nothing.
+    /// viewer showing nothing. (The ingest handler caps frame size, so
+    /// that overshoot is bounded.)
+    ///
+    /// Trimming drops WHOLE chunks and never truncates one. It must stay
+    /// that way: one chunk is one sealed encryption record, so a
+    /// truncated chunk would hand the viewer a record it cannot open and
+    /// desynchronize its decoder for everything after it.
     pub fn push(&mut self, message: Bytes) {
         if message.is_empty() {
             return;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -19,30 +19,60 @@ use std::collections::VecDeque;
 /// Chunks are raw terminal bytes, so a joiner's catch-up message is a
 /// single concatenation. Eviction is O(1). `Bytes` chunks share their
 /// buffers with the live broadcast path instead of copying.
+///
+/// Two independent bounds, because they guard different things. The byte
+/// budget is the memory bound: a chunk is a coalesced frame of up to
+/// 64KB (plus periodic full-screen keyframes), so counting frames alone
+/// left a room's ceiling at frames x 64KB. The frame count bounds
+/// per-chunk overhead instead - every chunk costs a `Bytes` in the deque
+/// and a step in `accumulated`'s walk, so without it a producer writing
+/// a byte at a time could sit inside the byte budget while holding
+/// millions of slivers. Which bound binds depends on frame size: below
+/// the budget-over-count average the frame cap wins (interactive typing
+/// keeps its full 200 frames), while any fast output - a build log, a
+/// `cat` - coalesces into large frames and is bounded by bytes instead.
 pub struct MessageHistory {
     chunks: VecDeque<Bytes>,
     max_messages: usize,
+    max_bytes: usize,
+    /// Sum of `chunks`' lengths, maintained on every push and eviction
+    bytes: usize,
 }
 
 impl MessageHistory {
-    /// An empty history holding at most `max_messages` messages.
-    pub const fn new(max_messages: usize) -> Self {
+    /// An empty history holding at most `max_messages` messages and
+    /// `max_bytes` bytes, whichever binds first.
+    pub const fn new(max_messages: usize, max_bytes: usize) -> Self {
         Self {
             chunks: VecDeque::new(),
             max_messages,
+            max_bytes,
+            bytes: 0,
         }
     }
 
-    /// Append a message, evicting the oldest when full. Empty messages
-    /// are dropped rather than allowed to evict real history.
+    /// Append a message, evicting the oldest until both bounds hold.
+    /// Empty messages are dropped rather than allowed to evict real
+    /// history.
+    ///
+    /// The newest chunk always survives, even when it alone exceeds the
+    /// byte budget: dropping it would silently discard the very output
+    /// being broadcast, and a viewer showing one oversized frame beats a
+    /// viewer showing nothing.
     pub fn push(&mut self, message: Bytes) {
         if message.is_empty() {
             return;
         }
-        if self.chunks.len() == self.max_messages {
-            self.chunks.pop_front();
-        }
+        self.bytes += message.len();
         self.chunks.push_back(message);
+        while self.chunks.len() > self.max_messages
+            || (self.bytes > self.max_bytes && self.chunks.len() > 1)
+        {
+            let Some(dropped) = self.chunks.pop_front() else {
+                break;
+            };
+            self.bytes -= dropped.len();
+        }
     }
 
     /// The whole history as one contiguous message, or `None` when
@@ -51,8 +81,7 @@ impl MessageHistory {
         if self.chunks.is_empty() {
             return None;
         }
-        let total: usize = self.chunks.iter().map(Bytes::len).sum();
-        let mut all = Vec::with_capacity(total);
+        let mut all = Vec::with_capacity(self.bytes);
         for chunk in &self.chunks {
             all.extend_from_slice(chunk);
         }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -665,8 +665,22 @@ async fn ws_ingest_handler(
         .on_upgrade(move |socket| ws_ingest_loop(socket, state, room_id, secret, claimed))
 }
 
-/// Largest ingest frame accepted, well above the client's 64KB batch.
+/// Largest ingest frame accepted. Must stay >= the client's
+/// `MAX_BUFFERED_BYTES` (`src/cli/ws.rs`), which is the largest chunk it
+/// will ever hold: a chunk the client keeps but the server refuses sits
+/// at the head of its replay buffer and is rewritten on every reconnect,
+/// so nothing behind it is ever delivered. They are equal today; lower
+/// this, or raise that, and the two must move together.
 const MAX_INGEST_FRAME: usize = 1024 * 1024;
+
+/// Largest control (text) frame accepted. Control messages are a few
+/// hundred bytes; the cap exists because the `size` value is stored
+/// verbatim for the room's whole life and re-sent to every viewer on
+/// connect - outside the history budget. Without a bound, one bloated
+/// `size` (the protocol only requires that `cols` and `rows` be present)
+/// pins megabytes per room, far more than the history it sits beside,
+/// since a parsed `serde_json::Value` costs several times its wire size.
+const MAX_CONTROL_FRAME: usize = 4 * 1024;
 
 /// How long the ingest loop waits for ANY frame before declaring the
 /// broadcaster dead. The client pings every 30s even when idle, so only
@@ -728,6 +742,16 @@ async fn ws_ingest_loop(
                     received_bytes += frame_len;
                 }
                 (result, true)
+            }
+            WsMessage::Text(text) if text.len() > MAX_CONTROL_FRAME => {
+                warn!(
+                    "WS ingest for room {:?}: {} byte control frame over the {} cap; ignoring",
+                    room_id,
+                    text.len(),
+                    MAX_CONTROL_FRAME
+                );
+                // Still proof the peer is alive, so the room stays fresh
+                (state.rooms.append(&room_id, &secret, None, None).map(|_| ()), false)
             }
             WsMessage::Text(text) => {
                 let Ok(body) = serde_json::from_str::<serde_json::Value>(&text) else {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -655,8 +655,18 @@ async fn ws_ingest_handler(
     };
 
     info!("WS ingest connected for room {:?}", room_id);
-    ws.on_upgrade(move |socket| ws_ingest_loop(socket, state, room_id, secret, claimed))
+    // The history's byte budget can still be overshot by one frame - the
+    // newest chunk always survives, whatever its size - so the frame size
+    // is what actually closes the ceiling. Without this a single frame
+    // could be tungstenite's 64MiB default and sit in the room for the
+    // whole TTL. The client coalesces to 64KB (`MAX_BATCH`), so this is
+    // ample headroom for anything a real broadcaster sends.
+    ws.max_message_size(MAX_INGEST_FRAME)
+        .on_upgrade(move |socket| ws_ingest_loop(socket, state, room_id, secret, claimed))
 }
+
+/// Largest ingest frame accepted, well above the client's 64KB batch.
+const MAX_INGEST_FRAME: usize = 1024 * 1024;
 
 /// How long the ingest loop waits for ANY frame before declaring the
 /// broadcaster dead. The client pings every 30s even when idle, so only
@@ -721,6 +731,14 @@ async fn ws_ingest_loop(
             }
             WsMessage::Text(text) => {
                 let Ok(body) = serde_json::from_str::<serde_json::Value>(&text) else {
+                    // Unparseable, but it still proves the peer is alive:
+                    // refresh the room, or a client sending only these
+                    // would hold the connection open while its room aged
+                    // out underneath it
+                    let result = state.rooms.append(&room_id, &secret, None, None);
+                    if result.is_err() {
+                        break;
+                    }
                     continue;
                 };
                 if body.get("delete").and_then(serde_json::Value::as_bool) == Some(true) {
@@ -751,9 +769,12 @@ async fn ws_ingest_loop(
                 let size = body
                     .get("size")
                     .filter(|s| protocol::size_has_dimensions(s));
-                size.map_or((Ok(()), false), |size| {
-                    (ingest(&state, &room_id, &secret, Some(size), None), true)
-                })
+                size.map_or_else(
+                    // Some other control message, or a size with no
+                    // dimensions: nothing to store, but the peer is alive
+                    || (state.rooms.append(&room_id, &secret, None, None).map(|_| ()), false),
+                    |size| (ingest(&state, &room_id, &secret, Some(size), None), true),
+                )
             }
             // axum answers pings itself; a ping still refreshes the room
             // so an idle-but-connected broadcast isn't evicted

--- a/src/server/rooms.rs
+++ b/src/server/rooms.rs
@@ -44,15 +44,17 @@ const MAX_HISTORY_MESSAGES: usize = 200;
 /// `src/cli/screen.rs`) so a late joiner can reconstruct a long-running
 /// TUI, and that only works while the newest keyframe is still inside
 /// the replayed window. The 59 frames that can follow it are up to
-/// 69,631 bytes each (`MAX_BATCH` is checked before a read of up to
-/// 4096 extends the batch, so the cap is exceeded by design), which is
-/// ~4.1MB before the keyframe itself is counted.
+/// 69,631 bytes of terminal output each (`MAX_BATCH` is checked before a
+/// read of up to 4096 extends the batch, so the cap is exceeded by
+/// design), plus a 32-byte record header when encrypted - ~4.1MB before
+/// the keyframe itself is counted.
 ///
-/// 8MB therefore leaves ~3.9MB of headroom for the keyframe: ample for a
-/// text TUI (btop at 400x100 truecolor dumps ~47KB) and enough for the
-/// per-cell truecolor extreme (a full-screen image render is ~1.4MB at
-/// that size). Frame count, batch size, and keyframe cadence all feed
-/// this number - if any of them moves, redo the arithmetic.
+/// 8MB therefore leaves ~4.2MB of headroom, and no keyframe can exceed
+/// 1MB: the client drops any chunk over its own replay-buffer cap before
+/// sending, and the ingest handler would refuse it anyway. So the
+/// guarantee holds with room to spare (a text TUI's keyframe measures
+/// ~47KB). Frame count, batch size, and keyframe cadence all feed this
+/// number - if any of them moves, redo the arithmetic.
 const MAX_HISTORY_BYTES: usize = 8 * 1024 * 1024;
 
 /// Minimum lifetime for a room with a broadcaster attached, used only

--- a/src/server/rooms.rs
+++ b/src/server/rooms.rs
@@ -48,6 +48,14 @@ const MAX_HISTORY_MESSAGES: usize = 200;
 /// stay above 60 x 64KB. Keep the two in lockstep if either moves.
 const MAX_HISTORY_BYTES: usize = 4 * 1024 * 1024;
 
+/// Minimum lifetime for a room with a broadcaster attached, used only
+/// when it exceeds the configured TTL - which in practice means a TTL
+/// shorter than the client's 30s keepalive, since a quiet broadcast
+/// refreshes its room no more often than that. On the 6h default this
+/// never binds. Comfortably above the server's 90s ingest idle timeout,
+/// which detaches genuinely dead connections. See [`Rooms::evict_stale`].
+const BROADCASTER_GRACE: Duration = Duration::from_secs(300);
+
 /// A canonical room identifier.
 ///
 /// Construction is the only place normalization happens: the `/r/` route
@@ -205,7 +213,13 @@ impl Rooms {
         self.inner.get(room).map(|entry| RoomSnapshot {
             size: entry.size.clone(),
             history: entry.messages.accumulated(),
-            broadcasting: entry.broadcasters > 0,
+            // Freshness, not just the count: an ingest task that died
+            // without running its detach leaves the count above zero, and
+            // without this the viewer's online dot would stay lit on a
+            // broadcast that ended. A live broadcaster pings every 30s,
+            // so it is always well inside the window.
+            broadcasting: entry.broadcasters > 0
+                && entry.last_activity.elapsed() <= BROADCASTER_GRACE,
         })
     }
 
@@ -322,12 +336,20 @@ impl Rooms {
         // make it underflow
         let mut evicted = 0;
         self.inner.retain(|_, room| {
-            // An attached broadcaster IS the room's liveness: a quiet
-            // producer refreshes activity only via 30s keepalive pings,
-            // which any shorter TTL outruns. A dead connection is
-            // detached by the ingest idle timeout first, and only then
-            // does its room start aging.
-            let keep = room.broadcasters > 0 || now.duration_since(room.last_activity) <= ttl;
+            // A quiet producer refreshes its room only through 30s
+            // keepalive pings, so a TTL shorter than that would evict a
+            // live broadcast; an attached broadcaster therefore gets at
+            // least BROADCASTER_GRACE. It is a floor, not an exemption:
+            // the attach count is decremented only when `ws_ingest_loop`
+            // returns normally (there is no Drop guard), so an absolute
+            // exemption would let a leaked count pin a room for the life
+            // of the process. Every room still ages out.
+            let deadline = if room.broadcasters > 0 {
+                ttl.max(BROADCASTER_GRACE)
+            } else {
+                ttl
+            };
+            let keep = now.duration_since(room.last_activity) <= deadline;
             if !keep {
                 evicted += 1;
             }

--- a/src/server/rooms.rs
+++ b/src/server/rooms.rs
@@ -42,11 +42,18 @@ const MAX_HISTORY_MESSAGES: usize = 200;
 /// The floor is set by keyframes, not by taste: the client emits a
 /// full-screen redraw every 60 broadcast frames (`FRAMES_PER_KEYFRAME`,
 /// `src/cli/screen.rs`) so a late joiner can reconstruct a long-running
-/// TUI, and that only works if the newest keyframe is still in the
-/// window being replayed. A budget below 60 max-size frames could evict
-/// one before the next arrives, regressing issue #164 - so this must
-/// stay above 60 x 64KB. Keep the two in lockstep if either moves.
-const MAX_HISTORY_BYTES: usize = 4 * 1024 * 1024;
+/// TUI, and that only works while the newest keyframe is still inside
+/// the replayed window. The 59 frames that can follow it are up to
+/// 69,631 bytes each (`MAX_BATCH` is checked before a read of up to
+/// 4096 extends the batch, so the cap is exceeded by design), which is
+/// ~4.1MB before the keyframe itself is counted.
+///
+/// 8MB therefore leaves ~3.9MB of headroom for the keyframe: ample for a
+/// text TUI (btop at 400x100 truecolor dumps ~47KB) and enough for the
+/// per-cell truecolor extreme (a full-screen image render is ~1.4MB at
+/// that size). Frame count, batch size, and keyframe cadence all feed
+/// this number - if any of them moves, redo the arithmetic.
+const MAX_HISTORY_BYTES: usize = 8 * 1024 * 1024;
 
 /// Minimum lifetime for a room with a broadcaster attached, used only
 /// when it exceeds the configured TTL - which in practice means a TTL

--- a/src/server/rooms.rs
+++ b/src/server/rooms.rs
@@ -4,8 +4,8 @@
 //!
 //! - **First-caller-wins claiming**: the first broadcast to a room name
 //!   claims it with that request's password; later requests must match.
-//! - **Bounded history**: at most [`MAX_HISTORY_MESSAGES`] messages are
-//!   kept per room for late joiners.
+//! - **Bounded history**: a room keeps at most [`MAX_HISTORY_MESSAGES`]
+//!   messages and [`MAX_HISTORY_BYTES`] bytes for late joiners.
 //! - **Canonical names**: a [`RoomId`] is normalized at construction, so
 //!   no caller can accidentally address a phantom room.
 //! - **Rooms outlive their broadcaster**: a session ends by closing, not
@@ -33,6 +33,20 @@ use std::time::{Duration, Instant};
 /// This prevents unbounded memory growth while keeping enough history
 /// for a good late-joiner experience.
 const MAX_HISTORY_MESSAGES: usize = 200;
+
+/// Memory budget for one room's history. Rooms outlive their broadcaster
+/// now, so the server holds every room broadcast within the TTL rather
+/// than just the live ones - and a message is a coalesced batch of up to
+/// 64KB, which left the per-room ceiling at 200 x 64KB ~ 12MB.
+///
+/// The floor is set by keyframes, not by taste: the client emits a
+/// full-screen redraw every 60 broadcast frames (`FRAMES_PER_KEYFRAME`,
+/// `src/cli/screen.rs`) so a late joiner can reconstruct a long-running
+/// TUI, and that only works if the newest keyframe is still in the
+/// window being replayed. A budget below 60 max-size frames could evict
+/// one before the next arrives, regressing issue #164 - so this must
+/// stay above 60 x 64KB. Keep the two in lockstep if either moves.
+const MAX_HISTORY_BYTES: usize = 4 * 1024 * 1024;
 
 /// A canonical room identifier.
 ///
@@ -92,7 +106,8 @@ pub struct RoomSnapshot {
 struct Room {
     /// The password that claimed this room
     password: String,
-    /// Message history, capped at [`MAX_HISTORY_MESSAGES`]
+    /// Message history, capped by [`MAX_HISTORY_MESSAGES`] and
+    /// [`MAX_HISTORY_BYTES`]
     messages: MessageHistory,
     /// Terminal size, forwarded verbatim to viewers
     size: Option<serde_json::Value>,
@@ -115,7 +130,7 @@ impl Room {
     fn new(password: &str) -> Self {
         Self {
             password: password.to_string(),
-            messages: MessageHistory::new(MAX_HISTORY_MESSAGES),
+            messages: MessageHistory::new(MAX_HISTORY_MESSAGES, MAX_HISTORY_BYTES),
             size: None,
             live_since: None,
             last_activity: Instant::now(),
@@ -225,7 +240,7 @@ impl Rooms {
         if entry.broadcasters > 1 {
             return Ok(());
         }
-        entry.messages = MessageHistory::new(MAX_HISTORY_MESSAGES);
+        entry.messages = MessageHistory::new(MAX_HISTORY_MESSAGES, MAX_HISTORY_BYTES);
         entry.last_activity = Instant::now();
         Ok(())
     }


### PR DESCRIPTION
Follow-up to #171. That change made rooms outlive the process that created them, which turned a room's memory from "held while broadcasting" into "held for up to 6h after". This bounds what a room can cost.

## What was unbounded

**History was capped by frame count, not bytes.** 200 messages sounds small until you notice a message is a coalesced batch — up to 69,631 bytes (`MAX_BATCH` is checked *before* a 4096-byte read extends the batch, so it's exceeded by design). That put one room's history near 14 MB.

**The `size` message was worse, and entirely outside that cap.** The protocol only requires `cols` and `rows` be present, and the server stores the value verbatim for the room's whole life and re-sends it to every viewer. A review measured **8.5 MB of RSS per room** from a single 520 KB size frame — a parsed `serde_json::Value` costs several times its wire size. 20 MB of traffic became 340 MB resident, held for hours.

**And a single frame had no limit at all.** The ingest upgrade never set one, leaving tungstenite's 64 MiB default.

## What this does

- **A byte budget on history**, alongside the frame count. The two guard different things and both stay: bytes bound memory; the frame count bounds per-chunk overhead and `accumulated()`'s walk, so a producer writing one byte at a time can't sit inside the budget holding millions of slivers.
- **8 MB, derived rather than picked.** The client emits a keyframe every 60 frames so a late joiner can reconstruct a running TUI (#164). For that to work the keyframe must still be in the replayed window: 59 following frames × 69,631 = 4.1 MB, leaving 4.2 MB of headroom against a keyframe that can never exceed 1 MB. Frame count, batch size and keyframe cadence all feed this number — the comment says so, and says to redo the arithmetic if any of them moves.
- **A 4 KiB cap on control frames**, which bounds the `size` hole without giving up the deliberate leniency that lets the client add fields (`theme`, `encrypted`) the server needn't understand. The CLI's largest control frame is ~100 bytes.
- **A 1 MiB cap on ingest frames**, which is what actually closes the ceiling since the newest chunk always survives regardless of size.
- **A lifetime floor instead of an eviction exemption.** A room with an attached broadcaster was exempt from TTL eviction — but the attach count is only decremented when `ws_ingest_loop` returns normally (there's no `Drop` guard), so a task that died without running its detach pinned that room for the life of the process. It now gets a *floor*, not an exemption, and the same freshness gates the `broadcasting` flag so a leaked count can't leave a viewer's online dot lit forever.
- **Every ingest path refreshes the room.** Only frames that appended did, but two receive paths don't append — unparseable text, and control JSON with no usable size. A client sending only those held its connection open while its room expired underneath it.

## Compatibility

No shipping client is affected. `MAX_BUFFERED_BYTES` has been 1 MiB since v3.6.0 and the client drops any larger chunk before sending, so `MAX_INGEST_FRAME` is exactly the largest frame a client can transmit — verified empirically: 1,048,576 bytes is acked, 1,048,577 is refused. That equality is load-bearing and now documented on both constants, because if they ever diverge the client would replay a frame the server always rejects and block everything behind it.

## Review

Three adversarial review rounds, which found: the keyframe guarantee my first constant claimed didn't actually hold (the arithmetic used 64 KB instead of the real 69,631); the `size` hole above; and **two of my own tests that passed against an unfixed server**. One asserted `pytest.raises(Exception)`, which the client's own read timeout satisfies whether or not the server caps anything; it now asserts what the room *holds*. The other was deleted rather than fixed — an attached room's 300s lifetime floor makes the behavior unobservable at any TTL a CI test can use, and the commit says so.

Every new test was verified to fail against a server without its fix.

## Known limits, deliberately not fixed here

- **Total memory is still unbounded**: per-room is capped, room *count* is not. A global cap needs LRU eviction across a sharded `DashMap` and an eviction policy that can't kill a live session — worth its own change.
- The floor-not-exemption change and the `broadcasting` freshness gate have **no test** distinguishing them from the old behavior, because `BROADCASTER_GRACE` isn't injectable at CI timescales.

## Testing

`make lint` clean, **249 e2e tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
