### PR TITLE
test: wait for the QR rows instead of assuming one scrape caught them

### DIFF
--- a/e2e/test_cli_tty.py
+++ b/e2e/test_cli_tty.py
@@ -257,9 +257,12 @@ class TestTtyBroadcast:
         assert cli.wait_for_screen("Scan this QR code with your phone:"), (
             f"No QR prompt on CLI screen. Screen: {cli.screen!r}"
         )
-        assert any(ch in cli.screen for ch in "▀▄█"), (
-            f"No terminal QR block characters on CLI screen. Screen: {cli.screen!r}"
-        )
+        # Keep scraping: stdout is line-buffered on a TTY, so the prompt line
+        # lands in the PTY before the QR rows underneath it are written. A
+        # bare assert here catches the gap between the two writes.
+        assert poll_until(
+            lambda: any(ch in cli.screen for ch in "▀▄█"), timeout=10
+        ), f"No terminal QR block characters on CLI screen. Screen: {cli.screen!r}"
         cli.send("exit\n")
         cli.wait_exit()
 


### PR DESCRIPTION
## What broke

`test_cli_tty.py::TestTtyBroadcast::test_terminal_output_includes_phone_qr_code` failed on `main` right after #174 merged:

```
AssertionError: No terminal QR block characters on CLI screen.
Screen: 'Sharing terminal in http://127.0.0.1:54737/r/test-...\r\n\r\n
         Scan this QR code with your phone:\r\n                          '
```

The captured screen is the tell: the prompt line arrived, and nothing under it.

## Why

`emit_human_sharing_message` (`src/cli/mod.rs:164`) writes the URL line, then the "Scan this QR code" line, then the QR rows, with a single `flush()` at the end — but stdout is line-buffered on a TTY, so each line reaches the PTY on its own. The test waits for the prompt line with `wait_for_screen`, which returns the instant that write lands, and then asserts on rows that have not been written yet.

Three sibling assertions in the same file (lines 236, 284, 314) already `poll_until` for exactly this reason. This one didn't.

## Not caused by #174

- That PR's diff to `src/cli/mod.rs` covers the imports, the signal handler, and `stream_stdin` — the QR/script-mode print path is in none of its hunks.
- The same commit passed this test in four other runs today: PR ubuntu, PR macos, and both e2e legs inside the release workflow.

## Verification

Honest about the limits: I could not reproduce the original failure locally — 20 runs of the test under 32 busy loops on 8 cores, plus two full `-n 10` suite runs under the same load, all green. That matches a flake that hit 1 of this commit's 5 CI runs. The fix is therefore structural rather than measured: it removes the gap between the two writes instead of widening a timeout. The fixed test passes 10/10 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)