### PR TITLE
ci: stop running the release workflow's work twice

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,16 +10,39 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  # Run E2E tests before building
+  # Gate the build on E2E, but only for tags. A push to main already runs
+  # both suites through their own workflows (e2e.yml and e2e-windows.yml
+  # trigger on `push: main` themselves), so calling them here as well ran
+  # the whole suite twice for every push - twice the wall clock, and twice
+  # the exposure to a flake, which is how the same green commit produced one
+  # red run and one passing one. A tag has to run them inline, because
+  # neither workflow triggers on tags.
   e2e-linux:
+    if: github.ref_type == 'tag'
     uses: ./.github/workflows/e2e.yml
 
   e2e-windows:
+    if: github.ref_type == 'tag'
     uses: ./.github/workflows/e2e-windows.yml
 
-  # Pass 1: Build bare binaries (no embedding) for all platforms
+  # Pass 1: Build bare binaries (no embedding) for all platforms.
+  #
+  # On a branch this is the only thing that compiles musl and x86_64 macOS,
+  # runs the embedding pass, and builds the Docker image - the E2E workflows
+  # only ever build natively for their own runner - so it stays as a smoke
+  # test that catches a cross-compile break before a tag exists to waste.
   build-bare:
     needs: [e2e-linux, e2e-windows]
+    # A skipped `needs` would skip this job by default, so decide explicitly:
+    # run unless a gate actually failed. The last clause drops the branch half
+    # of a release push - release.sh pushes main and the tag atomically, which
+    # fires two runs of this workflow, and the tag one is the one that
+    # publishes.
+    if: >-
+      ${{ !cancelled()
+          && !contains(needs.*.result, 'failure')
+          && !(github.ref_type == 'branch'
+               && startsWith(github.event.head_commit.message, 'chore: release')) }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## The two duplications

**1. E2E ran twice for every push to `main`.** `release.yml` pulls in `e2e.yml` and `e2e-windows.yml` via `workflow_call`, but both already trigger on `push: main` on their own. Same commit, same suite, two runs — which is how the merge of #174 produced a red standalone run and a green in-workflow run at the same time, and read as "the merge broke CI" when nothing had:

| run | trigger | result |
|---|---|---|
| `30389482297` E2E Tests | push/main | ❌ QR flake |
| `30389482679` Release → e2e-linux | push/main | ✅ |

**2. The whole workflow ran twice for every release.** `release.sh` does `git push --atomic origin main "v$version"`, and one push carrying two refs fires two runs:

```
07-25T19:44  push/v3.10.1  success  chore: release v3.10.1
07-25T19:44  push/main     success  chore: release v3.10.1
07-25T17:10  push/v3.10.0  success  chore: release v3.10.0
07-25T17:10  push/main     failure  chore: release v3.10.0   <- red, no consequence
```

Roughly 23 job-minutes across 14 jobs, run twice for one release.

## What changes

- The e2e gate runs **only for tags**. Tags need it inline (neither e2e workflow triggers on a tag); branches already have it.
- `build-bare` skips **the branch half of a release push**, so the atomic push builds once, on the tag that actually publishes.
- Because a skipped `needs` skips its dependents by default, `build-bare` decides explicitly with `!cancelled() && !contains(needs.*.result, 'failure')`.

## What deliberately does not change

Branch pushes keep building the matrix. It is the only thing that compiles `x86_64-unknown-linux-musl` and `x86_64-apple-darwin`, runs the embedding pass, and builds the Docker image — the e2e workflows only ever `cargo build --release` natively for their own runner. Catching a cross-compile break on `main` is worth the minutes; discovering it at tag time is not, because a tag cannot be reused.

Net effect: a normal `main` push goes from ~14 jobs to the build matrix alone, a release from two full matrices to one, and the flake surface halves.

## Verification, and its limit

`actionlint` 1.7.12 is clean across all three workflows, and I confirmed it actually type-checks these expressions by feeding it a deliberately broken one (`github.ref_typo`), which it rejected.

The limit worth stating plainly: **`release.yml` has no `pull_request` trigger**, so this PR's own CI cannot exercise the change. The first real run is the merge to `main` — expect the two e2e jobs *skipped* and the build matrix green. If it misbehaves there, the revert is one commit and no release is at risk in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)