### PR TITLE
ci: stop the skipped e2e gate from skipping the build chain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,11 @@ jobs:
   # Pass 2: Build with embedded binaries from Pass 1
   build-embedded:
     needs: build-bare
+    # Skipping propagates down the whole chain, not just one level: with the
+    # e2e gate skipped on a branch, this was skipped too even though
+    # build-bare had succeeded, which quietly cost the branch smoke test its
+    # embedding and Docker coverage. Decide from this job's own needs.
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') }}
     strategy:
       fail-fast: false
       matrix:
@@ -193,6 +198,8 @@ jobs:
   # Build and push Docker image to GHCR
   docker:
     needs: build-embedded
+    # Same reason as build-embedded: the skip would otherwise reach this far.
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Follow-up to #176, fixing a flaw its own first run exposed.

## What happened

#176 skipped the e2e gate on branch pushes and gave `build-bare` an explicit condition so it would run regardless. That part worked. But the run on the merge commit came out like this:

```
e2e-linux:       skipped
e2e-windows:     skipped
build-bare (×4): success     <- the override worked
build-embedded:  skipped     <- ...and then this
docker:          skipped
release:         skipped     (correct - tag-gated)
publish-npm:     skipped     (correct - tag-gated)
```

`build-embedded` has `needs: build-bare`, and `build-bare` was green above it.

## Why

Skipping propagates down the **entire chain**, not one level. A job whose condition is the default `success()` is skipped when any *ancestor* was skipped — including one it doesn't name in its own `needs`, and even when its direct dependency succeeded.

So the branch smoke test quietly shrank to the four bare binaries and lost precisely the coverage #176 argued for keeping: the embedding pass and the Docker image. The run still reported **success**, which is the part I like least about it.

## The fix

`build-embedded` and `docker` now decide from their own `needs`, the same way `build-bare` already does:

```yaml
if: ${{ !cancelled() && !contains(needs.*.result, 'failure') }}
```

The tag path was never affected — nothing is skipped there, so `release` and `publish-npm` keep working off plain `success()` and stay gated on `refs/tags`. Every job in the chain now has an explicit condition.

## On testing

This could not have been caught before merging: `release.yml` has no `pull_request` trigger, and the propagation only manifests in a run where something upstream is genuinely skipped. The verification is the same as last time — actionlint clean, and then the merge run itself, which should now show the e2e jobs skipped and `build-bare` → `build-embedded` → `docker` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)