### PR TITLE
fix: bound the WebSocket handshake so a silent peer cannot wedge the CLI

### DIFF
--- a/e2e/test_cli_stdin.py
+++ b/e2e/test_cli_stdin.py
@@ -19,8 +19,10 @@ import os
 import platform
 import re
 import signal
+import socket
 import subprocess
 import sys
+import threading
 import time
 
 import pytest
@@ -29,6 +31,7 @@ import requests
 from conftest import (
     CLI_COMMAND,
     SERVER_URL,
+    SHARED_PORT,
     SocketListener,
     parse_share_key,
     poll_until,
@@ -458,8 +461,232 @@ class TestAuthorization:
         # during concurrent access (depends on implementation)
 
 
+def _room_snapshot(room):
+    """True once the room holds broadcast bytes on the shared server."""
+    response = requests.get(f"{SERVER_URL}/r/{room}.bin", timeout=5)
+    return response.status_code == 200 and bool(response.content)
+
+
 class TestErrorHandling:
     """Tests for error handling."""
+
+    def test_silent_peer_fails_instead_of_hanging(self, unique_room, unique_password):
+        """A peer that accepts TCP and never answers must not wedge the CLI.
+
+        The WebSocket handshake writes the upgrade request and then reads
+        the `101 Switching Protocols` response. Without a read timeout on
+        that read, a peer that completes the TCP connection and then goes
+        silent (a wedged server, a load balancer fronting a dead backend,
+        a tarpitting firewall) parks the CLI in `recvfrom` forever, before
+        it ever prints the share URL (issue #173).
+
+        So the connect attempt has to give up on its own, and the two
+        elapsed-time bounds are what make this test mean something. The
+        lower one rejects a vacuous pass: a connect that fails for any
+        *other* reason - a refused port, an unresolvable host, a URL
+        rejected before dialling - exits non-zero with this same message
+        too, but instantly, having never reached the read under test.
+        The upper one holds the CLI to a budget rather than to merely
+        finishing, so a handshake bounded at, say, 55s would still fail
+        here. Both are anchored on `HANDSHAKE_TIMEOUT` in
+        `src/cli/ws.rs` (10s), with room for an oversubscribed runner.
+        """
+        listener = socket.socket()
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(8)
+        port = listener.getsockname()[1]
+        accepted = []
+        stop = threading.Event()
+
+        def accept_loop():
+            listener.settimeout(0.2)
+            while not stop.is_set():
+                try:
+                    # Held open, never written to: the CLI's upgrade
+                    # request is read by nobody and answered by nobody.
+                    # (The kernel would complete the TCP handshake from
+                    # the backlog anyway; accepting explicitly is what
+                    # lets the assertion below prove the CLI got that
+                    # far, on every platform.)
+                    accepted.append(listener.accept()[0])
+                except socket.timeout:
+                    continue
+                except OSError:
+                    break
+
+        thread = threading.Thread(target=accept_loop, daemon=True)
+        thread.start()
+        try:
+            args = CLI_COMMAND + [
+                "-s", f"http://127.0.0.1:{port}",
+                "-r", unique_room,
+                "-W", unique_password,
+            ]
+            proc = subprocess.Popen(
+                args,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            started = time.time()
+            try:
+                _, stderr = proc.communicate(input="hello\n", timeout=60)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.communicate()
+                pytest.fail(
+                    "CLI never gave up on a peer that accepted the connection "
+                    "and never answered the WebSocket handshake"
+                )
+            elapsed = time.time() - started
+        finally:
+            stop.set()
+            thread.join(timeout=5)
+            for conn in accepted:
+                conn.close()
+            listener.close()
+
+        assert accepted, "CLI never connected; the handshake read was never reached"
+        assert 5 < elapsed < 40, (
+            f"CLI gave up after {elapsed:.2f}s, outside the budget a 10s "
+            f"handshake timeout implies: {stderr!r}"
+        )
+        assert proc.returncode != 0, (
+            f"CLI reported success against a silent peer: {stderr}"
+        )
+        assert "error connecting to the server" in stderr, (
+            f"Expected a connect error on stderr, got: {stderr!r}"
+        )
+
+    def test_silent_peer_on_reconnect_does_not_wedge_the_session(
+        self, unique_room, unique_password
+    ):
+        """A live session whose server goes silent must still be able to end.
+
+        This is the severe half of issue #173, and it is reached only
+        after a successful connect, so the test above cannot cover it: by
+        reconnect time the CLI's signal handlers are installed, and they
+        only set atomic flags that the top of the stream loop reads. A
+        handshake blocked forever in `recvfrom` never returns to that
+        loop, so SIGINT, SIGTERM and SIGHUP were all absorbed and the
+        process needed SIGKILL - and EOF on stdin, the ordinary way a
+        stream-mode session ends, was ignored just as thoroughly.
+
+        A TCP proxy in front of the shared server plays the peer that
+        wedges mid-session: it relays until the broadcast is live, then
+        cuts the connection and answers every later one with silence.
+        Closing stdin must still end the session. (Asserting on EOF
+        rather than on a signal keeps the test meaningful on Windows,
+        where `send_signal(SIGTERM)` is an unconditional TerminateProcess
+        and would pass against any implementation.)
+        """
+        proxy = socket.socket()
+        proxy.bind(("127.0.0.1", 0))
+        proxy.listen(8)
+        proxy_port = proxy.getsockname()[1]
+        silent = threading.Event()
+        stop = threading.Event()
+        relayed = []  # sockets of the live session, cut when the peer wedges
+        stalled = []  # connections accepted after that, never answered
+
+        def cut(sock):
+            # shutdown, not just close: a pump thread is parked in recv()
+            # on this socket, and that in-flight syscall keeps the kernel
+            # side alive past close() - the FIN would not reach the CLI
+            # until something else woke the reader (its 30s keepalive
+            # ping, in practice)
+            try:
+                sock.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            sock.close()
+
+        def pump(src, dst):
+            try:
+                while True:
+                    data = src.recv(65536)
+                    if not data:
+                        break
+                    dst.sendall(data)
+            except OSError:
+                pass
+
+        def accept_loop():
+            proxy.settimeout(0.2)
+            while not stop.is_set():
+                try:
+                    client = proxy.accept()[0]
+                except socket.timeout:
+                    continue
+                except OSError:
+                    break
+                if silent.is_set():
+                    stalled.append(client)
+                    continue
+                try:
+                    upstream = socket.create_connection(("127.0.0.1", SHARED_PORT))
+                except OSError:
+                    client.close()
+                    continue
+                relayed.extend((client, upstream))
+                for src, dst in ((client, upstream), (upstream, client)):
+                    threading.Thread(
+                        target=pump, args=(src, dst), daemon=True
+                    ).start()
+
+        thread = threading.Thread(target=accept_loop, daemon=True)
+        thread.start()
+        proc = subprocess.Popen(
+            CLI_COMMAND + [
+                "-s", f"http://127.0.0.1:{proxy_port}",
+                "-r", unique_room,
+                "-W", unique_password,
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            proc.stdin.write("before the outage\n")
+            proc.stdin.flush()
+            # 200 AND non-empty: a room that does not exist yet answers
+            # 404 with a body, which a length check alone would take for
+            # a live broadcast - and cutting the connection that early
+            # kills the session's FIRST handshake instead of a reconnect
+            assert poll_until(lambda: _room_snapshot(unique_room), timeout=30), (
+                "CLI never broadcast through the proxy"
+            )
+
+            # The peer wedges: the live connection is cut, and every
+            # reconnect from here on is accepted and left unanswered
+            silent.set()
+            for sock in relayed:
+                cut(sock)
+            relayed.clear()
+            assert poll_until(lambda: bool(stalled), timeout=30), (
+                "CLI never tried to reconnect"
+            )
+            assert proc.poll() is None, "CLI exited before its session was ended"
+
+            proc.stdin.close()  # EOF: end the session
+            try:
+                proc.wait(timeout=60)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                pytest.fail(
+                    "CLI ignored EOF while a reconnect sat blocked on a silent "
+                    "peer - the state where every termination signal is absorbed"
+                )
+        finally:
+            stop.set()
+            thread.join(timeout=5)
+            for sock in relayed + stalled:
+                cut(sock)
+            proxy.close()
+            proc.kill()
+            proc.communicate()
 
     def test_large_input_chunked_successfully(self, unique_room, unique_password, socket_listener):
         """

--- a/e2e/test_cli_stdin.py
+++ b/e2e/test_cli_stdin.py
@@ -686,7 +686,15 @@ class TestErrorHandling:
                 cut(sock)
             proxy.close()
             proc.kill()
-            proc.communicate()
+            # Closed by hand rather than through communicate(): stdin is
+            # already closed by now, and before 3.13 communicate() tries
+            # to flush it and raises ValueError for its trouble
+            for stream in (proc.stdin, proc.stdout, proc.stderr):
+                try:
+                    stream.close()
+                except (OSError, ValueError):
+                    pass
+            proc.wait(timeout=30)  # reap; kill() alone leaves a zombie
 
     def test_large_input_chunked_successfully(self, unique_room, unique_password, socket_listener):
         """

--- a/src/cli/ws.rs
+++ b/src/cli/ws.rs
@@ -22,11 +22,12 @@ use crate::protocol::TermSize;
 use serde_json::json;
 use std::collections::VecDeque;
 use std::io::ErrorKind;
-use std::net::TcpStream;
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 use std::time::{Duration, Instant};
-use tungstenite::client::IntoClientRequest;
-use tungstenite::http::{header, HeaderValue, StatusCode};
-use tungstenite::stream::MaybeTlsStream;
+use tungstenite::client::{uri_mode, IntoClientRequest};
+use tungstenite::handshake::HandshakeError;
+use tungstenite::http::{header, HeaderValue, StatusCode, Uri};
+use tungstenite::stream::{MaybeTlsStream, Mode};
 use tungstenite::{Bytes, Error as WsError, Message, WebSocket};
 
 /// Cap on data held for (re)delivery. When exceeded, the oldest chunks
@@ -37,6 +38,25 @@ const INITIAL_BACKOFF: Duration = Duration::from_millis(250);
 const MAX_BACKOFF: Duration = Duration::from_secs(5);
 /// How long shutdown may wait for the final acknowledgments.
 const SHUTDOWN_DRAIN: Duration = Duration::from_secs(1);
+/// Total budget for the TCP dial, shared across every address the
+/// server's hostname resolves to (see `dial`). Ten seconds is the same
+/// bound as the write timeout below: long enough for a slow link or a
+/// cold serverless backend, short enough that a black-holed address
+/// becomes a retry rather than a wait.
+const DIAL_TIMEOUT: Duration = Duration::from_secs(10);
+/// Budget for the whole WebSocket upgrade once connected - TLS
+/// handshake, request write and `101 Switching Protocols` response.
+/// Also ten seconds: a server that has accepted the connection but
+/// cannot finish the upgrade within it is not one worth waiting on, and
+/// the reconnect backoff will try again anyway.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+/// Ceiling on how often a stalled upgrade is retried while it waits.
+const HANDSHAKE_POLL: Duration = Duration::from_millis(5);
+/// Floor on what a single address gets out of `DIAL_TIMEOUT`, so a name
+/// with many addresses cannot leave the first one - usually the one
+/// that will answer - too little time to complete a TCP handshake over
+/// a high-latency link.
+const MIN_DIAL_ATTEMPT: Duration = Duration::from_secs(3);
 /// Keepalive cadence. Pings refresh the room's activity server-side (so
 /// an idle-but-attached broadcast isn't TTL-evicted), keep NAT mappings
 /// alive, and turn a dead idle connection into a prompt reconnect.
@@ -379,6 +399,23 @@ impl Transport {
     /// One connection attempt. A definitive 401 is fatal; anything else
     /// arms the backoff and lets the caller try again later. On success
     /// the per-connection state (backoff, acks, size) is reset.
+    ///
+    /// The dial is done here rather than by `tungstenite::connect`,
+    /// which offers no way to bound any part of it: it resolves,
+    /// connects, writes the upgrade request and then blocks reading the
+    /// response on a socket with no timeouts at all. A peer that accepts
+    /// the connection and then says nothing parked this thread in
+    /// `recvfrom` forever, and since every termination signal only sets
+    /// a flag that a blocked thread never reads, the process needed
+    /// SIGKILL (issue #173). Now the dial is bounded by `DIAL_TIMEOUT`
+    /// and the upgrade by `HANDSHAKE_TIMEOUT`, so an unresponsive peer
+    /// is just another `Connect` error feeding the reconnect backoff.
+    ///
+    /// One thing `tungstenite::connect` did that this does not: follow
+    /// redirects. Nothing needs it - the `Location` would have to name a
+    /// `ws://` or `wss://` URL to be usable at all, and an https
+    /// redirect (what a real server in front of shellshare sends) failed
+    /// on the old path too.
     fn handshake(&mut self) -> Result<WsSocket, TransportError> {
         let result = (|| {
             let mut request = self
@@ -390,13 +427,63 @@ impl Transport {
                 .map_err(|e| TransportError::Connect(format!("invalid password: {e}")))?;
             request.headers_mut().insert(header::AUTHORIZATION, auth);
 
-            match tungstenite::connect(request) {
-                Ok((socket, _response)) => Ok(socket),
-                Err(WsError::Http(response)) if response.status() == StatusCode::UNAUTHORIZED => {
-                    Err(TransportError::Unauthorized)
+            let stream = dial(request.uri())?;
+            // Non-blocking for the upgrade, so ONE deadline covers the
+            // whole exchange rather than one deadline per syscall. A
+            // socket read timeout would bound each read separately, and
+            // every read that returns a byte restarts it: a peer
+            // trickling header bytes just under that timeout would stay
+            // inside tungstenite's parse loop for as long as its
+            // anti-DoS limits allow (512 packets, i.e. over an hour).
+            // It also covers the write side, and the TLS handshake for
+            // wss, which happen through the same stream.
+            stream
+                .set_nonblocking(true)
+                .map_err(|e| TransportError::Connect(e.to_string()))?;
+            let deadline = Instant::now() + HANDSHAKE_TIMEOUT;
+
+            // `client_tls_with_config` handles both modes: with no
+            // connector given it wraps the stream in rustls for wss and
+            // passes it through for ws, building the connector from the
+            // same webpki root store `tungstenite::connect` used.
+            let mut attempt = tungstenite::client_tls_with_config(request, stream, None, None);
+            // Long enough that a stalled peer is not polled hot, short
+            // enough that it adds nothing measurable to a local connect
+            let mut idle = Duration::from_micros(200);
+            let socket = loop {
+                match attempt {
+                    Ok((socket, _response)) => break socket,
+                    Err(HandshakeError::Failure(WsError::Http(response)))
+                        if response.status() == StatusCode::UNAUTHORIZED =>
+                    {
+                        return Err(TransportError::Unauthorized)
+                    }
+                    Err(HandshakeError::Failure(e)) => {
+                        return Err(TransportError::Connect(e.to_string()))
+                    }
+                    // Nothing to read or write yet. Every platform
+                    // reports this the same way (WSAEWOULDBLOCK
+                    // included), and the mid-handshake state owns the
+                    // socket, so giving up here closes it.
+                    Err(HandshakeError::Interrupted(mid)) => {
+                        if Instant::now() >= deadline {
+                            return Err(TransportError::Connect(format!(
+                                "no handshake response after {}s",
+                                HANDSHAKE_TIMEOUT.as_secs()
+                            )));
+                        }
+                        std::thread::sleep(idle);
+                        idle = (idle * 2).min(HANDSHAKE_POLL);
+                        attempt = mid.handshake();
+                    }
                 }
-                Err(e) => Err(TransportError::Connect(e.to_string())),
-            }
+            };
+
+            // Back to blocking: `drain_acks` owns the non-blocking reads
+            // from here on, and `write` relies on blocking sends
+            set_nonblocking(socket.get_ref(), false)
+                .map_err(|()| TransportError::Connect("cannot restore socket".into()))?;
+            Ok(socket)
         })();
 
         match result {
@@ -423,9 +510,71 @@ impl Transport {
     }
 }
 
+/// Open the TCP connection for a `ws`/`wss` URL within `DIAL_TIMEOUT`.
+///
+/// A hostname routinely resolves to several addresses - shellshare.net
+/// alone answers with two IPv4 and two IPv6 - and `connect_timeout`
+/// takes exactly one, so every candidate is tried in the resolver's
+/// order (which already encodes the OS's source-address preference).
+/// The budget is *shared*: each attempt gets an equal slice of what is
+/// left, so a black-holed IPv6 address cannot spend the time its IPv4
+/// sibling needs, and the whole dial still ends within `DIAL_TIMEOUT`.
+///
+/// Name resolution itself stays blocking - `getaddrinfo` has no timeout
+/// to give it - but it is bounded by the resolver's own retry limits,
+/// unlike the silent-peer read this function exists to bound.
+fn dial(uri: &Uri) -> Result<TcpStream, TransportError> {
+    let mode = uri_mode(uri).map_err(|e| TransportError::Connect(e.to_string()))?;
+    let host = uri
+        .host()
+        .ok_or_else(|| TransportError::Connect(format!("no host in {uri}")))?;
+    // A literal IPv6 host is bracketed in a URL; the resolver wants it bare
+    let host = host
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host);
+    let port = uri.port_u16().unwrap_or(match mode {
+        Mode::Plain => 80,
+        Mode::Tls => 443,
+    });
+
+    let addrs: Vec<SocketAddr> = (host, port)
+        .to_socket_addrs()
+        .map_err(|e| TransportError::Connect(format!("cannot resolve {host}: {e}")))?
+        .collect();
+    let deadline = Instant::now() + DIAL_TIMEOUT;
+    let mut left = addrs.len();
+    let mut last_error = None;
+    for addr in addrs {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let slice = (remaining / u32::try_from(left).unwrap_or(u32::MAX))
+            .max(MIN_DIAL_ATTEMPT)
+            .min(remaining);
+        left -= 1;
+        if slice.is_zero() {
+            break; // out of budget (and connect_timeout rejects zero)
+        }
+        match TcpStream::connect_timeout(&addr, slice) {
+            Ok(stream) => {
+                // Broadcasts are many small frames; Nagle would only add
+                // delay, and the handshake is the first thing to profit
+                let _ = stream.set_nodelay(true);
+                return Ok(stream);
+            }
+            Err(e) => last_error = Some(e),
+        }
+    }
+    Err(TransportError::Connect(last_error.map_or_else(
+        || format!("could not connect to {host}:{port}"),
+        |e| format!("could not connect to {host}:{port}: {e}"),
+    )))
+}
+
 /// Low-latency, bounded-blocking socket options. Broadcasts are many
 /// small frames, so Nagle's algorithm would only add delay; the write
 /// timeout turns a dead connection into a reconnect instead of a hang.
+/// Nothing to undo from the handshake: it bounds itself by polling a
+/// non-blocking socket rather than by arming a socket timeout.
 fn configure_tcp(stream: &MaybeTlsStream<TcpStream>) {
     if let Some(tcp) = tcp_stream(stream) {
         let _ = tcp.set_nodelay(true);


### PR DESCRIPTION
Fixes #173.

## What broke

A peer that accepts the TCP connection and then says nothing wedged the broadcasting client forever.

`tungstenite::connect` resolves DNS, dials, writes the upgrade request, and then blocks reading `101 Switching Protocols` on a socket with no timeouts at all. The transport's only socket timeout was a **write** timeout, set by `configure_tcp` *after* the handshake returned. So the reconnect backoff spaced out the attempts while each individual attempt could sit in `recvfrom` indefinitely.

Two symptoms, and they are not equally bad:

- **Initial connect** — hangs before the share URL is ever printed. Still killable, since no signal handler is installed yet.
- **Reconnect** — by then the handlers *are* installed, and they only set atomic flags that the top of the stream loop reads. A thread blocked in a syscall never reaches that check, so SIGINT, SIGTERM and SIGHUP are all absorbed and the process needs `SIGKILL`.

Measured on a release build of `origin/main`:

```
initial connect : STILL RUNNING after 25s, no stdout, no stderr
reconnect       : survived SIGINT, SIGINT, SIGTERM, SIGHUP -> needed SIGKILL
```

## The fix

`Transport::handshake` now owns the dial instead of delegating it:

1. `uri_mode` picks `ws`/`wss` and the default port; the name is resolved and every address is dialled with `TcpStream::connect_timeout` under a shared 10s budget.
2. The upgrade runs over that stream via `client_tls_with_config(request, stream, None, None)` — passing no connector keeps the identical implicitly-built webpki root store that `connect` used.
3. The upgrade is bounded by **one deadline against a non-blocking socket**, not by a socket read timeout.

Point 3 is the non-obvious part, and it came out of review. A read timeout bounds each read *separately*, and any read that returns a byte restarts it — so a peer trickling header bytes just under the limit stays inside tungstenite's parse loop for as long as its anti-DoS limits allow (512 packets, i.e. over an hour). An intermediate version of this PR did exactly that and was measured **still stuck after 100s** against a tarpit dribbling 140 bytes every 3s. Polling a non-blocking socket against a single `Instant` ends it in 10s, and covers the write side and the TLS handshake for free.

Multi-address resolution: `shellshare.net` answers with two IPv4 and two IPv6 addresses, and `connect_timeout` takes exactly one. Every candidate is tried in the resolver's order (which already encodes the OS's source-address preference), sharing the budget so a black-holed IPv6 address cannot spend the time its IPv4 sibling needs — with a 3s floor per attempt, so splitting 10s four ways can't starve the first, usually-correct address on a high-latency link.

## How it was verified

Every number below is observed, not inferred. "pre-fix" is a release build of `origin/main`.

| scenario | pre-fix | this PR |
|---|---|---|
| silent peer, initial connect | running after 25s, no output | exits 10.0s, rc=1, `no handshake response after 10s` |
| silent peer, reconnect (proxy) | absorbed SIGINT×2 / SIGTERM / SIGHUP, needed SIGKILL | 2nd Ctrl+C exits rc=0; EOF ends it in ~10s |
| tarpit dribbling 140B every 3s | stuck past 60s | exits 10.0s |
| wrong password (401) | fatal, instant | fatal, 0.00s, same message |
| `wss://shellshare.net` | works | works — broadcast stored, `/r/<room>.bin` → 200, 49 bytes |
| honest server 8s slow to answer | works | works, 8.1s, rc=0 |
| IPv6 literal (`http://[::1]:port`) | works | works |
| blackholed address (reviewer) | 133.2s | 10.03s |
| refused / unresolvable | instant | instant, better message |

Gates: `make lint` clean; `cargo build --release`; `cd e2e && uv run pytest -n 10` → **255 passed**, and 255 passed again under 3× CPU oversubscription (24 busy loops on 8 cores).

## Tests

Two, because the two paths fail independently — a fix bounding only `Transport::connect` would pass a startup-only test and still leave every live broadcast needing `kill -9`.

- `test_silent_peer_fails_instead_of_hanging` — a listener that accepts and never writes; asserts a connect error and a non-zero exit, bracketed by elapsed-time bounds on *both* sides. The lower bound rejects a vacuous pass (a refused port fails with the same message in 0.0s); the upper one holds the CLI to a budget, so a 55s handshake bound would still fail.
- `test_silent_peer_on_reconnect_does_not_wedge_the_session` — a TCP proxy in front of the shared server relays until the broadcast is live, then cuts the connection and answers every reconnect with silence; closing stdin must still end the session. It asserts on EOF rather than a signal so it stays meaningful on Windows, where `send_signal` is an unconditional `TerminateProcess` and would pass against any implementation.

Both were written first and **run against the pre-fix binary, where both fail** (60s and 120s timeouts respectively); both pass in ~10s each against this build. The new tests were also run 5× consecutively with identical timings.

## Behaviour changes to be aware of

- **Redirects are no longer followed.** `tungstenite::connect` allowed three. A `Location` has to name `ws://`/`wss://` to be usable at all, and the https redirect a real server sends (`http://shellshare.net` → `https://…`) failed on the old path too, so no realistic case regresses — but a server answering the ingest handshake with a `ws://` redirect would.
- **Dial errors read differently**: `could not connect to host:port: Connection refused (os error 111)` instead of tungstenite's generic `Unable to connect to ws://…`. No doc or test asserts the old text.

## What I could NOT verify

- **Windows and macOS beyond "the suite is green".** Both CI jobs pass, including the two new tests, so the code paths run there. What I could not do is reproduce the *bug* on either: the pre-fix/post-fix comparison above is Linux-only. The non-blocking path should be more uniform across platforms than a read timeout would have been (`WSAEWOULDBLOCK` maps to the same `Interrupted` variant, whereas `WSAETIMEDOUT` would not have), but that is reasoning, not measurement.
- The first CI run caught a real portability bug in my own test cleanup — `communicate()` after `stdin.close()` raises on Python 3.12 and is swallowed on 3.13, which is what my machine runs. Fixed and re-verified by running the whole suite under 3.12. Worth knowing that local green does not imply CI green for this suite.
- **Real-world flaky networks.** The 3s per-address floor and the 10s budgets are reasoned, not measured against a satellite or congested mobile link. A user whose TCP handshake genuinely needs >10s across all addresses will now see a retry where they previously saw a very slow success — the backoff retries, so this degrades rather than breaks.
- **The dribbling-tarpit bound under TLS.** Verified over plain `ws://` only; the TLS handshake goes through the same non-blocking stream and the same deadline, but I did not build a TLS tarpit.
- **DNS resolution is still unbounded by us.** `getaddrinfo` has no timeout to give it; it is bounded only by the resolver's own retry limits. Unchanged from before, and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
