### PR TITLE
docs: state that the viewer WebSocket opens with the room's history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,8 +100,20 @@ fragment the server never sees, so you decrypt locally (Node's built-in
   accumulated history as raw bytes — opaque ciphertext, since the server
   is an end-to-end-encryption-blind relay. Decrypt with the `#` key.
 - **Follow** (live): open a WebSocket to `/ws/v/r/<room>`. On connect the
-  server sends the catch-up snapshot, then live frames. Binary frames are
-  ciphertext records; text frames are control JSON you can ignore.
+  server sends the catch-up snapshot (the `size` control frame, the room's
+  history, then `broadcasting` and `usersCount`), and live frames after
+  that. Binary frames are ciphertext records; text frames are control JSON
+  you can ignore.
+
+Pick one; do not chain them. Following already begins with the history that
+`.bin` would have handed you, so snapshot-then-follow prints it twice. The
+same replay happens on every reconnect — deliberately, because it makes a
+dropped connection a clean resync rather than a gap, which is why the viewer
+page wipes its screen on rejoin — so a reconnect means "discard and start
+over", not "continue where I left off". `usersCount` is the last frame of
+the replay and marks where live output begins. Delivery is at-least-once,
+not exactly-once: a frame broadcast just as you connect can arrive both in
+the history and as a live frame.
 
 Both are a sequence of self-delimiting records:
 `[u32 BE N][12-byte nonce][ciphertext || 16-byte GCM tag]`, where

--- a/templates/llms.txt
+++ b/templates/llms.txt
@@ -39,6 +39,14 @@ Given a link `.../r/<room>#<key>`:
 - Live: WebSocket `/ws/v/r/<room>` → binary frames are ciphertext records;
   text frames are control JSON (ignore them).
 
+Use one or the other, not both in sequence: a WebSocket connect replays the
+room's history before its live frames, so the socket alone gives you both —
+fetching `.bin` first and then following duplicates the history. Every
+reconnect replays from the start too (that is what makes a dropped
+connection a resync instead of a gap), so treat a reconnect as "discard what
+I have and start over", never as a continuation. The `usersCount` control
+frame is the last of the replay, so it marks where live output begins.
+
 Both are a stream of self-delimiting records:
 `[u32 BE N][12-byte nonce][ciphertext || 16-byte GCM tag]`, where
 `N = 12 + len(ciphertext || tag)`, AES-256-GCM, key = the 64 hex chars after `#`.


### PR DESCRIPTION
Closes #179.

## What #179 found

Reading a broadcast by fetching `GET /r/<room>.bin` and *then* following `/ws/v/r/<room>` prints the terminal history twice, and each reconnect replays it again. The docs never said the socket starts with the history, so chaining them looks like the natural composition.

## Why this is a docs fix, not a server fix

The replay is deliberate and load-bearing. `src/server/mod.rs:419-491` pushes `size` → history → `broadcasting` → `usersCount` on every viewer connect, which is what makes a dropped connection a clean *resync* instead of a gap — the viewer page relies on it, wiping the screen with RIS on rejoin (`templates/room.html:466-471`), and it's the recovery path for viewers the server intentionally disconnects when they fall behind. Suppressing history on connect would break both.

The shipped reader never hits the duplication either: `agent.mjs --follow` uses the WebSocket *alone* (`templates/agent.mjs:96-151`), because the socket already yields history-then-live. Only a hand-rolled consumer reading the two raw bullets in `llms.txt` gets misled — which is exactly what happened.

## Changes

`templates/llms.txt` and `AGENTS.md` now state, on the read-side contract:

- a connect replays the history before live frames, so use the socket **or** `.bin`, not one then the other;
- every reconnect replays from the start, so a reconnect means "discard and start over", not "continue";
- `usersCount` is the last frame of the replay, so it marks where live output begins;
- delivery is at-least-once (`AGENTS.md` only): a frame broadcast just as you connect can arrive in both the history and the live stream (`src/server/mod.rs:464-466`).

No new test. The behavior is already locked by `e2e/test_viewer_ws.py:566` (`test_reconnect_delivers_history_once_per_connection`) and the snapshot ordering by the frame-order assertions in the same file; asserting a sentence exists in `llms.txt` would be the kind of trivial substring check CLAUDE.md says not to add.

Verified the rendered `/llms.txt` still serves the new paragraph, and `make lint` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)