### PR TITLE
security: scope workflow tokens and drop a dead innerHTML sink

### DIFF
--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -9,6 +9,10 @@ on:
       - main
   workflow_call:
 
+# See e2e.yml: build-and-test only, so read is all the token needs.
+permissions:
+  contents: read
+
 jobs:
   e2e-windows:
     runs-on: windows-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,12 @@ on:
       - main
   workflow_call:
 
+# The suite only builds and tests this repo's own source. Naming the scope
+# here keeps a compromised third-party action (or a build script from a PR)
+# from inheriting a write-capable token.
+permissions:
+  contents: read
+
 jobs:
   e2e:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,13 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# Default for the build and test jobs, which only compile this repo's source.
+# The three jobs that publish something (docker, release, publish-npm) each
+# override this with the narrower scope they actually need - a job-level block
+# replaces this one wholesale rather than adding to it.
+permissions:
+  contents: read
+
 jobs:
   # Gate the build on E2E, but only for tags. A push to main already runs
   # both suites through their own workflows (e2e.yml and e2e-windows.yml

--- a/templates/room.html
+++ b/templates/room.html
@@ -518,13 +518,13 @@ file verbatim.)
       }
       connect();
 
+      // textContent, not innerHTML: the count is always a number (the caller
+      // checks) so nothing here can render markup either way, but a text sink
+      // stays safe if that guard ever loosens - and it is what the assignment
+      // means.
       function onUsersCount(onlineUsers) {
-        onlineCounter.innerHTML = onlineUsers;
-        if (onlineUsers == 1) {
-          onlineCounterPlural.innerHTML = '';
-        } else {
-          onlineCounterPlural.innerHTML = 's';
-        }
+        onlineCounter.textContent = String(onlineUsers);
+        onlineCounterPlural.textContent = onlineUsers == 1 ? '' : 's';
       }
       // Whether the broadcaster's client is attached to the room right
       // now (it pings even when idle, so "live" means the session is


### PR DESCRIPTION
Resolves all ten open [code scanning alerts](https://github.com/vitorbaptista/shellshare/security/code-scanning). Each was re-checked against the current tree by independent agents, and the four false positives were re-checked again adversarially before being dismissed.

## Fixed — 6 alerts, `actions/missing-workflow-permissions` (medium)

`e2e.yml`, `e2e-windows.yml`, and four jobs in `release.yml` (`e2e-linux`, `e2e-windows`, `build-bare`, `build-embedded`) ran with the repository-default `GITHUB_TOKEN` scopes, far wider than the `contents: read` they use. These jobs run third-party actions and compile PR-authored build scripts, so a compromised action would hold a write-capable token.

One top-level `permissions: contents: read` per workflow. A job-level block replaces the top-level one wholesale, so `docker` (`packages: write`), `release` (`contents: write`), and `publish-npm` (`id-token: write`) keep exactly the scopes their publishing steps require — verified by parsing the YAML after the change.

## Fixed as cleanup — 1 alert, `js/xss` (high), **not exploitable**

`templates/room.html:522` was `onlineCounter.innerHTML = onlineUsers`. Three agents independently failed to find a flow:

- `onUsersCount` has exactly one caller, gated by `typeof control.usersCount === 'number'` (`room.html:487`). A JS number's string form cannot contain `<`, `&`, or a quote.
- The server only ever emits `format!("{{\"usersCount\":{count}}}")` with a `usize` (`src/server/viewers.rs:220,416`).
- The room name — the one attacker-chosen value — is never templated into the page; `room_page_response` serves a cached static page whose only substitutions are compile-time.
- The broadcaster-controlled `size` message was traced end to end: `cols`/`rows` are clamped to integers, `theme` is only a key into the compile-time `THEMES` table, `encrypted` picks between literal notices.

`git log -L` explains the alert: before the Socket.IO removal this was an unguarded `socket.on('usersCount', …)` handler. The taint path was real then; the rewrite added the guard and the alert was never re-triaged.

Switched to `textContent` anyway — it is what the assignment means, it silences the alert permanently, and it stays safe if the guard ever loosens. Behavior is identical and already covered: the e2e suite asserts on `#online-counter`'s `textContent` (`test_broadcast.py:121,138,154`).

## Dismissed, no code change — 3 alerts, `py/incomplete-url-substring-sanitization` (high)

`e2e/test_agents.py:345`, `e2e/test_cli_stdin.py:774`, `e2e/test_cli_tunnel.py:103` are pytest assertions on a sitemap body, `--help` output, and a fatal error string — all produced by our own binary. Nothing is sanitized, parsed as a URL, fetched, or trusted. A repo-wide sweep for security-relevant substring host checks found none: `is_secure_context_url` (`src/cli/mod.rs:109`) parses the authority and fails closed on `http://localhost@evil.com`, `extract_tunnel_url` anchors on a leading-dot suffix, and the http→ws conversion uses `strip_prefix`.

## Not verified locally

`cargo` is unavailable in this environment, so `make lint` and the e2e suite did not run here — CI covers both. The change is YAML and template-only, with no Rust touched and no placeholder affected, so `warm()` is unaffected.

## Follow-ups found but out of scope

- No `X-Content-Type-Options: nosniff` on `/r/:room.bin`, which returns attacker-controlled bytes as `application/octet-stream`. Not exploitable in current browsers, but free to add.
- `normalize_server_url` (`src/cli/mod.rs:127`) prepends `http://` to a scheme-less `--server`, and the room password rides as a plaintext `Authorization` header on that handshake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)