### PR TITLE
chore: ignore .claude/worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ e2e/loadgen/target/
 
 # Visual companion (brainstorming) scratch
 /.superpowers/
+
+# Claude Code worktrees
+/.claude/worktrees/


### PR DESCRIPTION
Adds `/.claude/worktrees/` to `.gitignore` so Claude Code worktrees don't show up as untracked changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)