### PR TITLE
fix: stop CDNs caching the /r/:room.bin snapshot for a month

### DIFF
--- a/e2e/test_agent_read.py
+++ b/e2e/test_agent_read.py
@@ -31,13 +31,13 @@ from conftest import (
 
 
 def _get_bin(room):
-    """GET /r/<room>.bin -> (status, body bytes)."""
+    """GET /r/<room>.bin -> (status, body bytes, headers)."""
     url = f"{SERVER_URL}/r/{urllib.parse.quote(room, safe='')}.bin"
     try:
         with urllib.request.urlopen(url, timeout=5) as resp:
-            return resp.status, resp.read()
+            return resp.status, resp.read(), resp.headers
     except urllib.error.HTTPError as e:
-        return e.code, e.read()
+        return e.code, e.read(), e.headers
 
 
 def test_bin_serves_ciphertext_that_decrypts_with_the_share_key(
@@ -53,8 +53,15 @@ def test_bin_serves_ciphertext_that_decrypts_with_the_share_key(
         SERVER_URL, unique_room, unique_password, text=f"{marker}\n", key=key
     )
 
-    status, body = _get_bin(unique_room)
+    status, body, headers = _get_bin(unique_room)
     assert status == 200
+    # The snapshot is live, mutating data. The `.bin` suffix that makes
+    # it agent-friendly is exactly what puts it on a CDN's default
+    # cacheable-extension list, so the origin must say no-store or an
+    # agent polling the room gets a month-old body back.
+    assert "no-store" in headers.get("Cache-Control", ""), (
+        "the snapshot is cacheable: a CDN will freeze it"
+    )
     assert len(body) > 0, "no history bytes served"
     # server-blind: the plaintext never appears in the relayed ciphertext
     assert marker.encode() not in body
@@ -107,5 +114,5 @@ def test_room_outlives_the_process_and_a_rerun_starts_fresh(
 
 
 def test_bin_unknown_room_is_404():
-    status, _ = _get_bin(f"no-such-room-{random_id()}")
+    status, _, _ = _get_bin(f"no-such-room-{random_id()}")
     assert status == 404

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -525,6 +525,16 @@ async fn room_get_handler(
             Response::builder()
                 .status(StatusCode::OK)
                 .header(header::CONTENT_TYPE, "application/octet-stream")
+                // Live, per-room, mutating bytes - never storable. The
+                // header has to be explicit because a CDN in front of us
+                // reads the `.bin` suffix as a static asset: with no
+                // origin `Cache-Control`, Cloudflare's default extension
+                // list gave this endpoint a month-long TTL and served
+                // agents a frozen snapshot with no way to tell. A short
+                // `max-age` would only shrink that window; the body is
+                // never reusable, so `no-store` (which already implies
+                // `private`) is the honest answer.
+                .header(header::CACHE_CONTROL, "no-store")
                 // Not HTML, so it cannot carry the page's `noindex`
                 // meta tag - and it is the response that would actually
                 // hold a broadcast's bytes


### PR DESCRIPTION
`GET /r/<room>.bin` — the agent-facing snapshot endpoint — set `Content-Type`
and the `noindex` header but no `Cache-Control` at all. With no origin cache
header, Cloudflare applies its defaults, and `.bin` sits on its default
cacheable-extension list with a Browser Cache TTL of exactly 2678400s (1 month).

Confirmed in production:

```
curl -sSI 'https://shellshare.net/r/<room>.bin'
# cache-control: max-age=2678400
# cf-cache-status: HIT
# age: 271
```

The impact is silent: an agent following the documented reader path
(`templates/agent.mjs`, `templates/llms.txt`) polls a live broadcast and gets a
frozen body with no signal that it is stale. Empirically, a cached response
returned 3622 bytes while a cache-busted request to the same room returned
10738.

The irony is the root cause: the `.bin` suffix chosen to make the endpoint
agent-friendly is exactly what makes a CDN classify it as a static asset. So the
header has to be explicit — the absence of one is not "don't cache", it is
"apply your defaults".

**Why `no-store` and not a short `max-age`.** The body is live, per-room,
mutating broadcast data that is never reusable — a second request one second
later can legitimately differ. Any TTL only shrinks the staleness window instead
of closing it, and leaves the endpoint storable by intermediaries holding
someone's terminal output. `no-store` already implies `private`, so adding
`private` buys nothing.

**Other routes checked, not changed.** The WebSocket routes (`/ws/r/:room`,
`/ws/v/r/:room`) upgrade to 101 and are never cached by a CDN — no exposure.
The room page goes through `serve_page`, which sends `public, no-cache` plus an
`ETag`: it revalidates on every request and the body is a static app shell with
no room data in it, so that is correct as-is. `CACHE_ONE_DAY` is used only for
`/llms.txt` and unversioned static assets, both of which are genuinely static.
No other route has a body that mutates without a cache header.

**Test.** `e2e/test_agent_read.py::test_bin_serves_ciphertext_that_decrypts_with_the_share_key`
— the test that already owns this endpoint — now also asserts the response
carries a `no-store` `Cache-Control`, rather than adding a second test that hits
the same URL. `e2e/test_agent_read.py` passes (3 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
