### PR TITLE
fix: paint the viewer terminal in the default theme before one arrives

### DIFF
--- a/public/javascript/room.js
+++ b/public/javascript/room.js
@@ -6,6 +6,10 @@
   // immutably cached asset shared by every room.
   var THEMES = JSON.parse(
     document.getElementById('themes').textContent);
+  // The CLI's default --theme, used until a size message names one.
+  // Must stay in lockstep with the default in src/main.rs and with the
+  // fallback colors hard-coded in room.css.
+  var DEFAULT_THEME = 'tango';
   // Matches the base terminal font size in room.css
   var BASE_FONT_PX = 14;
   // A raw WebSocket to /ws/v + this page's path: binary frames are
@@ -534,7 +538,13 @@
   ];
 
   function applyTheme(name) {
-    var entry = THEMES[name];
+    // Before the first size message (and for a theme this viewer
+    // doesn't know) fall back to the CLI's default theme rather than
+    // plain black/white: the terminal is created and painted as soon
+    // as the font loads, so an arbitrary fallback flashes against the
+    // theme that then lands - and tango is what most broadcasts send.
+    // Same reasoning as the CSS fallbacks in room.css.
+    var entry = THEMES[name] || THEMES[DEFAULT_THEME];
     var colors = {
       background: entry ? entry.background : '#000000',
       foreground: entry ? entry.foreground : '#f0f0f0',
@@ -590,9 +600,11 @@
   }
 
   function applyPageChrome(colors, entry) {
-    // No real theme yet (pre-size default, or an unknown name): leave
-    // the page at the CSS default (dark) rather than forcing it black,
-    // so there's no flash before the broadcaster's theme lands.
+    // Only if even the default theme is missing from the injected
+    // block: leave the page at the CSS defaults rather than forcing it
+    // black. Normally entry is the broadcast theme, or tango until one
+    // lands - and tango is exactly what those CSS defaults encode, so
+    // applying it here is a no-op repaint, not a flash.
     if (!entry) {
       return;
     }

--- a/public/stylesheet/room.css
+++ b/public/stylesheet/room.css
@@ -172,7 +172,12 @@ header {
    wrapping or clipping. */
 #terminal {
   position: relative;
-  background-color: black;
+  /* The default theme's (tango) background, matching --page-bg's
+     fallback above: the container is painted before any JS runs, and
+     the script overwrites it with the broadcast theme's background as
+     soon as one lands. Pure black here would flash against the far
+     more common tango terminal. */
+  background-color: #121314;
   padding: 5px;
   overflow-x: auto;
 }


### PR DESCRIPTION
The viewer's terminal was painted pure black until a broadcast theme arrived, so opening a room flashed black → tango's near-black (`#121314`) — and under a light theme like `solarized-light`, black → white.

Two fallbacks caused it, both now pointing at the CLI's own default theme:

- `public/stylesheet/room.css` — `#terminal` was `background-color: black`, the color the container shows before any JS runs. Now `#121314`, matching the `--page-bg` fallback right above it, which already encodes tango for exactly this reason.
- `public/javascript/room.js` — `applyTheme()` fell back to `#000000`/`#f0f0f0` for an absent or unknown theme name, and it runs at terminal creation (as soon as the webfont loads), well before the first `size` message. Now it falls back to the `tango` entry, so the pre-size paint and the paint that follows are identical for the common case. `applyPageChrome`'s `!entry` guard now only triggers if even the default theme is missing from the injected block.

`DEFAULT_THEME = 'tango'` is a new named constant in `room.js`, commented to stay in lockstep with the `--theme` default in `src/main.rs` and the hard-coded fallbacks in `room.css`.

Behavior once a `size` message lands is unchanged — `applyTheme` already set the container's background inline from the broadcast theme.

## Testing

- `make lint` clean
- `cd e2e && uv run pytest -n 10` — 259 passed
- Verified the built server serves both changes (`/stylesheet/room.bundle.css`, `/javascript/room.js`)

No new test: `e2e/test_theme.py` already covers theme application, and the fallback is a color constant with no observable behavior beyond the paint itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
