### PR TITLE
docs: drop the -y flag from the npx install command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Viewers see the terminal live in their browser, read-only.
 ## Install
 
 ```bash
-npx -y shellshare --help                 # no install (Node.js)
+npx shellshare --help                    # no install (Node.js)
 curl -sLo shellshare https://get.shellshare.net/ && chmod +x shellshare   # static binary (auto-detects OS)
 ```
 

--- a/e2e/test_api.py
+++ b/e2e/test_api.py
@@ -151,7 +151,7 @@ class TestInstallOptions:
         wait_for_server(SERVER_URL)
         status, headers, body = make_request('GET', '/')
         assert status == 200, f"Expected 200, got {status}"
-        assert 'npx -y shellshare' in body, "Expected npx install command on home page"
+        assert 'npx shellshare' in body, "Expected npx install command on home page"
 
     def test_os_options_present_but_unchecked(self):
         """The per-OS binary options should exist and be unchecked by default."""

--- a/npm/shellshare/README.md
+++ b/npm/shellshare/README.md
@@ -24,10 +24,10 @@ broadcast finishes. Errors go to stderr as `ERROR: ...` with a non-zero exit.
 
 ```bash
 # Share a single command live; exits with the command's exit code
-npx -y shellshare exec --json -- npm test
+npx shellshare exec --json -- npm test
 
 # Stream a log or any pipe (a non-TTY stdin auto-detects this, reads until EOF)
-tail -f build.log | npx -y shellshare --json
+tail -f build.log | npx shellshare --json
 ```
 
 Full agent-facing docs: [AGENTS.md](https://github.com/vitorbaptista/shellshare/blob/main/AGENTS.md) · [shellshare.net/llms.txt](https://shellshare.net/llms.txt)

--- a/templates/index.html
+++ b/templates/index.html
@@ -53,7 +53,7 @@
         "name": "How do I share my terminal live without signing up?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Run `npx -y shellshare` (or download the binary from https://get.shellshare.net). It prints a link like https://shellshare.net/r/abc123 - anyone who opens it watches your terminal live. Exit the shell to stop."
+          "text": "Run `npx shellshare` (or download the binary from https://get.shellshare.net). It prints a link like https://shellshare.net/r/abc123 - anyone who opens it watches your terminal live. Exit the shell to stop."
         }
       },
       {
@@ -112,7 +112,7 @@
       <section class="instructions">
         <div class="download">
           <code title="Click to copy">
-            <span class="node">npx -y shellshare</span>
+            <span class="node">npx shellshare</span>
             <span class="macos">curl -sLo shellshare https://get.shellshare.net/?os=mac &amp;&amp; chmod +x shellshare &amp;&amp; ./shellshare</span>
             <span class="linux">wget -qO shellshare https://get.shellshare.net/?os=linux &amp;&amp; chmod +x shellshare &amp;&amp; ./shellshare</span>
             <span class="windows">iwr https://get.shellshare.net/?os=windows -OutFile shellshare.exe; .\shellshare.exe</span>
@@ -134,7 +134,7 @@
         <p>Shellshare allows you to broadcast your terminal live with a single command. Read-only, end-to-end encrypted, great for teaching and presentations.</p>
         <h3>How to use?</h3>
         <p>Open a terminal and write:</p>
-        <pre class="demo" data-duration="5000"><code><span class="node">$ npx -y shellshare</span><span class="macos">$ curl -sLo shellshare https://get.shellshare.net/?os=mac
+        <pre class="demo" data-duration="5000"><code><span class="node">$ npx shellshare</span><span class="macos">$ curl -sLo shellshare https://get.shellshare.net/?os=mac
 $ chmod +x shellshare
 $ ./shellshare</span><span class="linux">$ wget -qO shellshare https://get.shellshare.net/?os=linux
 $ chmod +x shellshare
@@ -158,7 +158,7 @@ PS&gt; exit</span>
         <p>No. Shellshare was made only for live broadcasts. If you'd like to save your terminal, try <a href="https://asciinema.org">asciinema.org</a>.</p>
         <h3>Can I broadcast to a custom room name?</h3>
         <p>Yes. You can broadcast to a named room secured with a password by calling shellshare as:</p>
-        <pre><code><span class="node">$ npx -y shellshare --room MY-ROOM --password MY-PASS</span><span class="macos">$ curl -sLo shellshare https://get.shellshare.net/?os=mac
+        <pre><code><span class="node">$ npx shellshare --room MY-ROOM --password MY-PASS</span><span class="macos">$ curl -sLo shellshare https://get.shellshare.net/?os=mac
 $ chmod +x shellshare &amp;&amp; ./shellshare --room MY-ROOM --password MY-PASS</span><span class="linux">$ wget -qO shellshare https://get.shellshare.net/?os=linux
 $ chmod +x shellshare &amp;&amp; ./shellshare --room MY-ROOM --password MY-PASS</span><span class="windows">PS&gt; iwr https://get.shellshare.net/?os=windows -OutFile shellshare.exe
 PS&gt; .\shellshare.exe --room MY-ROOM --password MY-PASS</span>

--- a/templates/llms.txt
+++ b/templates/llms.txt
@@ -6,7 +6,7 @@ Site: https://shellshare.net
 
 ## Install
 
-`npx -y shellshare` (needs Node.js), or download the static binary then run
+`npx shellshare` (needs Node.js), or download the static binary then run
 `chmod +x shellshare && ./shellshare`:
 https://get.shellshare.net/?os=linux  (also: mac, mac-arm, windows; auto-detected from the User-Agent if omitted)
 


### PR DESCRIPTION
Every user-facing surface advertised `npx -y shellshare`. The flag only suppresses npm's one-time "Ok to proceed?" confirm, and it made the shortest way to try shellshare read like a command with options to understand. `npx shellshare` is what people type — and what the top-level README already showed — so the site, `llms.txt`, `AGENTS.md` and the npm package README now agree with it.

Changed:
- `templates/index.html` — the copy-to-clipboard install line, the typed demo, the FAQ named-room example, and the JSON-LD FAQ answer
- `templates/llms.txt` and `AGENTS.md` — the agent-facing install lines (comment column kept aligned)
- `npm/shellshare/README.md` — both scripting examples
- `e2e/test_api.py` — the home-page assertion matched the literal string, so it moves with the template

### Verification
- `make lint` clean
- `e2e/test_api.py -k TestInstallOptions` passes against a release build
- An adversarial review found no remaining `-y` variants anywhere (including `.github/`, `Makefile`, `src/`, package scripts), no other assertion on the old string, and no CSS/JS that depends on the literal command width — the demo's typing animation derives its per-character delay from the actual text length, so the 5s budget is unchanged.

### One trade-off, flagged
Without `-y`, a first run on a machine with a cold npx cache hits npm's `Ok to proceed? (y)` confirm. That matters most for the piped recipe in `npm/shellshare/README.md` (`tail -f build.log | npx shellshare --json`), where the prompt and the piped payload share stdin. Deliberate — the flag is being dropped on purpose — but worth knowing before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)