### PR TITLE
fix: stop a lost SIGWINCH wake-up hanging the client on exit

### DIFF
--- a/src/cli/script.rs
+++ b/src/cli/script.rs
@@ -20,7 +20,7 @@ use std::time::{Duration, Instant};
 #[cfg(unix)]
 use signal_hook::consts::SIGWINCH;
 #[cfg(unix)]
-use signal_hook::iterator::Signals;
+use signal_hook::iterator::{Signals, SignalsInfo};
 
 /// RAII guard to enable/restore terminal raw mode.
 /// This is essential for interactive apps like vim to work properly.
@@ -175,36 +175,48 @@ pub fn run_script_mode(
     #[cfg(unix)]
     let (resize_tx, resize_rx) = mpsc::channel::<PtySize>();
 
-    // Spawn SIGWINCH handler thread for dynamic terminal resize
+    // Watch SIGWINCH for dynamic terminal resize.
+    //
+    // Registered here, on this thread, rather than inside the worker
+    // below, because the `Handle` it yields is what stops that worker at
+    // the end of the session. Waking it with `raise(SIGWINCH)` instead
+    // raced with its own registration: SIGWINCH's default disposition is
+    // to be ignored, so a wake-up sent before the handler existed was
+    // discarded, the worker stayed parked in `forever()` and the join
+    // below never returned - a hang no termination signal could clear,
+    // since those only set flags a blocked thread never reads. Registering
+    // first closes the window; `close()` then needs no signal at all.
+    // `exec` is where it bit: a child like `sh -c 'exit 3'` produces no
+    // output, so nothing delays the teardown that races the worker's start.
     #[cfg(unix)]
-    let sigwinch_thread = {
-        let running_sigwinch = running.clone();
+    let sigwinch = Signals::new([SIGWINCH]).ok();
+    #[cfg(unix)]
+    let sigwinch_handle = sigwinch.as_ref().map(SignalsInfo::handle);
+    #[cfg(unix)]
+    let sigwinch_thread = sigwinch.map(|mut signals| {
         let cols = current_cols.clone();
         let rows = current_rows.clone();
 
-        let handle = thread::spawn(move || {
-            if let Ok(mut signals) = Signals::new([SIGWINCH]) {
-                for _ in signals.forever() {
-                    if !running_sigwinch.load(Ordering::SeqCst) {
-                        break;
-                    }
-                    // Get new terminal size
-                    let new_size = get_terminal_size();
-                    // Update shared size atomics
-                    cols.store(new_size.cols, Ordering::SeqCst);
-                    rows.store(new_size.rows, Ordering::SeqCst);
-                    // Send resize request to main loop (which owns the master)
-                    let _ = resize_tx.send(PtySize {
-                        rows: new_size.rows,
-                        cols: new_size.cols,
-                        pixel_width: 0,
-                        pixel_height: 0,
-                    });
-                }
+        thread::spawn(move || {
+            // Ends when the handle is closed, not on a flag: `forever()`
+            // blocks, so a flag would only be read after a signal that
+            // may never come.
+            for _ in signals.forever() {
+                // Get new terminal size
+                let new_size = get_terminal_size();
+                // Update shared size atomics
+                cols.store(new_size.cols, Ordering::SeqCst);
+                rows.store(new_size.rows, Ordering::SeqCst);
+                // Send resize request to main loop (which owns the master)
+                let _ = resize_tx.send(PtySize {
+                    rows: new_size.rows,
+                    cols: new_size.cols,
+                    pixel_width: 0,
+                    pixel_height: 0,
+                });
             }
-        });
-        Some(handle)
-    };
+        })
+    });
 
     // Channel for sending PTY output to the sender thread (non-blocking)
     let (tx, rx) = mpsc::channel::<Vec<u8>>();
@@ -449,12 +461,13 @@ pub fn run_script_mode(
     // Signal the remaining helper threads (stdin forwarder, SIGWINCH) to stop
     running.store(false, Ordering::SeqCst);
 
-    // Join SIGWINCH handler thread (Unix only)
+    // Join SIGWINCH handler thread (Unix only). Closing the handle ends
+    // its `forever()` loop directly - no signal to deliver, so nothing
+    // to lose, and this join always returns.
     #[cfg(unix)]
     if let Some(handle) = sigwinch_thread {
-        // Send SIGWINCH to ourselves to unblock the signal iterator
-        unsafe {
-            libc::raise(SIGWINCH);
+        if let Some(signals) = sigwinch_handle {
+            signals.close();
         }
         let _ = handle.join();
     }


### PR DESCRIPTION
E2E on `main` went red at d7dd0fc: `test_exec_propagates_exit_code` timed out after 60s. The same commit had passed on its own PR run, so this is a latent race that the commit only happened to be standing next to — not a regression in it.

## What happened

`shellshare exec -- sh -c 'exit 3'` printed its `sharing` event and then never exited. `{"event":"end","exit_code":3}` never arrived.

The SIGWINCH watcher registered its own signal handler from inside the thread it ran in, while teardown woke it from the outside with `raise(SIGWINCH)` and then joined it. Those race. SIGWINCH's default disposition is *ignore*, so a wake-up sent before the handler existed was discarded rather than queued — the watcher stayed parked in `forever()` with nothing left to wake it, and the join never returned. SIGINT/SIGTERM/SIGHUP only set flags a blocked thread never reads, so the process could only be SIGKILLed.

`exec` is where it surfaced because it makes the window widest at the narrow end: a child like `sh -c 'exit 3'` writes nothing, so there is no output to drain and no acks to wait for between spawning the watcher and tearing it down — sometimes only a single `try_wait` poll separates them. An interactive shell always lives long enough for the watcher to be registered.

## The fix

Register on the calling thread, before the watcher starts, and stop it through the `Handle` that registration yields. `close()` sets a flag the iterator checks on every pass and *then* wakes it, so unlike a signal it cannot be sent too early to be seen: it ends the loop whether the watcher is parked, mid-iteration, or has not reached `forever()` yet. Nothing is delivered, so nothing can be lost. Registering first also means a real resize during startup is buffered instead of dropped.

The watcher no longer checks `running` to break out, because it no longer needs a signal to leave. `resize_rx` outlives the join, so a resize racing the teardown just queues harmlessly.

## Verification

The natural race is too rare to catch on an idle box (0 hangs in 150 runs), so it was reproduced by widening it rather than waiting for it — one variable, nothing else changed:

| build | delay injected before the watcher registers | hangs |
|---|---|---|
| before | 300ms | 1 / 1 (survived SIGTERM; needed SIGKILL) |
| after | 300ms | 0 / 10 |

An independent reviewer reproduced the same result at a different delay: 3/8 before, 0/20 after.

Root cause was also confirmed directly on a wedged process: the main thread sat in `futex_do_wait` (the join) while a thread sat in `unix_stream_read_generic` (signal-hook's self-pipe).

Unmodified, 470 `exec` runs — 120 of them under 12 busy-loops on 8 cores — all exited 3 promptly. Full e2e suite: 259/259. `make lint` clean.

## Not in this PR

Adversarial review turned up a **separate, pre-existing** hang in the same teardown path, reproducible *on this patched build*: the PTY reader parks in a blocking `read()`, so the drain watchdog at `src/cli/script.rs:450-456` cannot actually interrupt it. The comment above it claims an orphan holding the slave open is bounded by a 2s grace period; it is not.

```
shellshare exec -- sh -c '(trap "" HUP; sleep 20) & exit 3'   # hangs 20s, not 2s
shellshare exec -- sh -c 'trap "" HUP; (trap "" HUP; sleep 600) & exit 3'
  -> SIGTERM-immune, no `end` event, killed by SIGKILL — the same signature as this CI failure
```

`sh -c 'exit 3'` spawns nothing, so it cannot have caused this CI break, and fixing it means making the master fd non-blocking — a change to the hot output path that does not belong in a PR whose job is to turn CI green. Left for a follow-up.

Also noted: CI runs no lint at all — `make lint` exists only as a local target, and neither workflow runs clippy or `-D warnings`.
