### PR TITLE
fix: bound the PTY drain, drop the viewer's theme transition, correct the MSRV

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,6 +16,31 @@ permissions:
   contents: read
 
 jobs:
+  # Everything else here builds on stable, so `rust-version` is a claim
+  # nothing tests - which is how it came to be three years out of date.
+  # Checking it costs one job and turns "we think this still builds on the
+  # oldest toolchain we advertise" into something we know.
+  msrv:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Read the declared MSRV
+        id: msrv
+        run: |
+          version=$(sed -n 's/^rust-version = "\(.*\)"/\1/p' Cargo.toml)
+          test -n "$version" || { echo "no rust-version in Cargo.toml" >&2; exit 1; }
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.version }}
+
+      - uses: Swatinem/rust-cache@v2
+
+      - run: cargo check --all-targets
+
   e2e:
     strategy:
       matrix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,13 @@ homepage = "https://shellshare.net"
 readme = "README.md"
 keywords = ["terminal", "broadcast", "shell", "live", "tty"]
 categories = ["command-line-utilities", "network-programming"]
-rust-version = "1.75"
+# What the dependency graph actually requires, not an aspiration: idna
+# (via url -> reqwest) pulls in icu_* 2.x, which declares 1.86. The old
+# 1.75 had been untrue for a while, because CI builds on stable and never
+# exercised it - so a 1.75-1.85 toolchain got a compile error out of rustc
+# instead of cargo's clean "package requires a newer rustc". The `msrv` job
+# in e2e.yml reads this line and builds against it, so it stays true.
+rust-version = "1.86"
 
 [features]
 default = []

--- a/e2e/test_agents.py
+++ b/e2e/test_agents.py
@@ -12,6 +12,7 @@ import json
 import os
 import platform
 import subprocess
+import time
 
 import pytest
 import requests
@@ -21,6 +22,7 @@ from conftest import (
     CLI_SESSION_TIMEOUT,
     SERVER_URL,
     SocketListener,
+    open_records,
     parse_share_key,
     random_id,
     wait_for_content,
@@ -147,6 +149,53 @@ class TestExecSubcommand:
         events = parse_json_events(proc.stdout)
         assert events[-1] == {"event": "end", "exit_code": 3}, \
             f"stdout was: {proc.stdout!r}"
+
+    @pytest.mark.skipif(IS_WINDOWS, reason="recipe uses a POSIX shell")
+    def test_exec_survives_a_silent_orphan(self, unique_room, unique_password):
+        """A descendant outliving the command must not hold the session open.
+
+        The command's exit is not the end of its terminal: anything it left
+        running keeps the PTY open, so the drain waits for output that will
+        never come. The orphan here ignores SIGHUP and prints nothing, so
+        only a clock can end that wait - and a clock only helps if the
+        waiting is interruptible, which a plain blocking read is not.
+
+        The tail must still survive the deadline and the JSON contract must
+        still close cleanly, or this trades a hang for a quieter bug.
+        """
+        marker = f"orphan-marker-{random_id()}"
+        # The orphan outlives the deadline by a wide margin on purpose: if
+        # the drain ever goes back to waiting for it, that has to fail
+        # unmistakably rather than land just the wrong side of the bound
+        recipe = f'trap "" HUP; (trap "" HUP; sleep 30) & echo {marker}; exit 3'
+        start = time.monotonic()
+        proc = subprocess.run(
+            CLI_COMMAND
+            + ["exec", "--json", "-s", SERVER_URL, "-r", unique_room, "-W", unique_password]
+            + ["--", "sh", "-c", recipe],
+            capture_output=True,
+            text=True,
+            timeout=CLI_SESSION_TIMEOUT,
+            stdin=subprocess.DEVNULL,
+        )
+        elapsed = time.monotonic() - start
+        assert proc.returncode == 3
+        # Generous next to the drain's own grace period, tight enough that
+        # an unbounded wait (which only ends when the orphan does) fails
+        assert elapsed < 8, f"exec took {elapsed:.1f}s to give up on the orphan"
+        events = parse_json_events(proc.stdout)
+        assert events[-1] == {"event": "end", "exit_code": 3}, \
+            f"stdout was: {proc.stdout!r}"
+        assert marker in proc.stdout, \
+            f"output produced before the orphan was lost: {proc.stdout!r}"
+        # And reached the room, not just the local terminal: giving up on
+        # the orphan must not mean giving up on delivering what came
+        # before it. The broadcast is encrypted, so read it the way a
+        # viewer would, with the key from the share link.
+        key = parse_share_key(events[0]["url"])
+        snapshot = requests.get(f"{SERVER_URL}/r/{unique_room}.bin")
+        assert marker.encode() in open_records(key, snapshot.content), \
+            "the drain gave up before broadcasting the output it had"
 
     def test_exec_requires_command(self):
         proc = subprocess.run(

--- a/public/javascript/room.js
+++ b/public/javascript/room.js
@@ -561,17 +561,7 @@
     root.setProperty('--page-fg', colors.foreground);
     root.setProperty('--page-muted', muted);
     root.setProperty('--page-accent', accent);
-    // The first apply must land instantly, with no fade from the
-    // pre-size default; only a live re-theme animates. Next frame, so
-    // this apply isn't caught by the transition.
-    if (!pageChromeApplied) {
-      pageChromeApplied = true;
-      requestAnimationFrame(function () {
-        document.body.classList.add('theme-transitions');
-      });
-    }
   }
-  var pageChromeApplied = false;
 
   // The `fullscreen` class on #terminal drives all layout, so browsers
   // without requestFullscreen on divs (iOS Safari) still get a

--- a/public/stylesheet/room.css
+++ b/public/stylesheet/room.css
@@ -46,12 +46,10 @@ body {
   color: var(--page-fg, #cccccc);
 }
 
-/* Animate only live theme changes (the broadcaster re-themes mid-session),
-   not the first paint - the initial apply must land instantly so there's
-   no fade from the pre-size default into the real theme. */
-body.theme-transitions {
-  transition: background-color 0.2s ease, color 0.2s ease;
-}
+/* Deliberately no transition on these. The only theme change a viewer
+   reliably sees is the fallback above becoming the broadcast's, and that
+   one is a repaint rather than a change: animating it is the flash, not
+   the cure. */
 
 /* The fallbacks below are tango's accent (bright blue) and muted tone,
    matching the script's output for the default theme - see above. */

--- a/src/cli/script.rs
+++ b/src/cli/script.rs
@@ -18,9 +18,54 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 #[cfg(unix)]
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+
+#[cfg(unix)]
 use signal_hook::consts::SIGWINCH;
 #[cfg(unix)]
 use signal_hook::iterator::{Signals, SignalsInfo};
+
+/// Bounds teardown, not throughput: the wait ends the moment the terminal
+/// has bytes, so it costs no output latency.
+#[cfg(unix)]
+const POLL_TIMEOUT_MS: libc::c_int = 100;
+
+#[cfg(unix)]
+enum Wait {
+    Readable,
+    Again,
+    Failed,
+}
+
+/// Hang-up counts as readable and must be read: the last output of a short
+/// command arrives with `POLLHUP` already set beside `POLLIN`, so treating
+/// it as the end would truncate the tail of every `exec -- echo hi`. The
+/// read that follows reports the real end.
+///
+/// A signal means "wait again" - `SA_RESTART` covers `read` but not
+/// `poll`, so a terminal resize interrupts this routinely. Anything else
+/// means we can no longer tell when the terminal has something to say:
+/// end the session, as a failing read always did, rather than stall on a
+/// wait that will keep failing or fall through to a read nothing can
+/// interrupt.
+#[cfg(unix)]
+fn wait_readable(fd: &OwnedFd, timeout_ms: libc::c_int) -> Wait {
+    let mut pollfd = libc::pollfd {
+        fd: fd.as_raw_fd(),
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    // SAFETY: one valid, initialized entry, and `fd` outlives the call.
+    let ready = unsafe { libc::poll(&raw mut pollfd, 1, timeout_ms) };
+    match ready {
+        0 => Wait::Again,
+        n if n > 0 => Wait::Readable,
+        _ if std::io::Error::last_os_error().kind() == std::io::ErrorKind::Interrupted => {
+            Wait::Again
+        }
+        _ => Wait::Failed,
+    }
+}
 
 /// RAII guard to enable/restore terminal raw mode.
 ///
@@ -137,6 +182,34 @@ pub fn run_script_mode(
         cmd.env(super::ENV_ROOM, session.room);
     }
 
+    // A descriptor of our own to wait on. The master's own would do until
+    // the drain watchdog closes it, at which point the number could be
+    // reissued to one of the sender thread's sockets and the reader would
+    // quietly wait on that. Readiness belongs to the terminal, so this and
+    // portable-pty's reader see the same bytes - and it is that reader's
+    // EIO-to-EOF mapping that ends the loop, where a raw read would report
+    // an error.
+    //
+    // Before the spawn, because failing here is fatal - without it the
+    // reader parks in a read nothing can interrupt - and refusing after
+    // the spawn would strand a running command.
+    #[cfg(unix)]
+    let poll_fd = {
+        let fd = pair
+            .master
+            .as_raw_fd()
+            .ok_or("this PTY has no descriptor to wait on")?;
+        // SAFETY: `fd` is the live master, owned by `pair`. Close-on-exec
+        // because plain dup() drops the flag portable-pty set on it and
+        // the child is spawned right below.
+        let duped = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
+        if duped < 0 {
+            return Err(Box::new(std::io::Error::last_os_error()));
+        }
+        // SAFETY: a fresh, exclusively-owned descriptor.
+        unsafe { OwnedFd::from_raw_fd(duped) }
+    };
+
     let mut child = pair.slave.spawn_command(cmd)?;
 
     let master = pair.master;
@@ -250,6 +323,36 @@ pub fn run_script_mode(
             }
         }
 
+        // Take what the reader still owes us. Only the EOF exit leaves the
+        // channel empty: `running` going false breaks the loop wherever it
+        // stood, and `shutdown` flushes only what already reached the
+        // transport, so the paths that exist to bound the wait would
+        // otherwise drop output the terminal had already produced.
+        //
+        // Waiting, not just draining what is queued, because the reader
+        // sees the same flag and may be between its read and its send -
+        // measured as a ~50ms window in which output reaches the room with
+        // this loop and is lost without it. Its sender dropping is the
+        // real end; the deadline only keeps this from becoming the
+        // unbounded wait the rest of the teardown just removed, and gates
+        // every pass because each send can itself sit on a socket timeout.
+        let size = TermSize {
+            cols: http_cols.load(Ordering::SeqCst),
+            rows: http_rows.load(Ordering::SeqCst),
+        };
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while Instant::now() < deadline {
+            match rx.recv_timeout(Duration::from_millis(20)) {
+                Ok(data) => {
+                    if transport.send(&data, size).is_err() {
+                        break;
+                    }
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                Err(mpsc::RecvTimeoutError::Timeout) => {}
+            }
+        }
+
         // Normal end (shell exit or Ctrl+C): flush pending output, then
         // close - the room stays up so the link keeps working
         transport.shutdown();
@@ -264,6 +367,19 @@ pub fn run_script_mode(
         loop {
             if !running_clone.load(Ordering::SeqCst) {
                 break;
+            }
+
+            // Bounded, so the check above stays reachable: the drain
+            // watchdog only flips that flag, and a thread parked in a
+            // blocking read never gets back to it. Enough while whatever
+            // holds the slave open keeps writing, since each write returns
+            // from read() - but a silent survivor (`sleep 30 &` under a
+            // shell ignoring SIGHUP) gives it nothing to return from.
+            #[cfg(unix)]
+            match wait_readable(&poll_fd, POLL_TIMEOUT_MS) {
+                Wait::Readable => {}
+                Wait::Again => continue,
+                Wait::Failed => break,
             }
 
             match reader.read(&mut read_buffer) {
@@ -285,6 +401,13 @@ pub fn run_script_mode(
                 Err(e) => {
                     if e.kind() == std::io::ErrorKind::WouldBlock {
                         thread::sleep(Duration::from_millis(10));
+                        continue;
+                    }
+                    // A signal is not the PTY closing. SA_RESTART means the
+                    // kernel resumes the read and this shouldn't surface,
+                    // but treating it as EOF would end a live session on a
+                    // stray signal.
+                    if e.kind() == std::io::ErrorKind::Interrupted {
                         continue;
                     }
                     // Likely the PTY closed
@@ -390,10 +513,14 @@ pub fn run_script_mode(
 
     // Close our copy of the slave BEFORE joining the reader thread.
     // The child has exited (or been killed and reaped, bounded) in every
-    // path that reaches here, so this is safe on Windows too (portable-pty
-    // only requires the slave to outlive the child). Without this, the
-    // master never sees EOF and the PTY reader thread can block in read()
-    // forever, hanging the join below.
+    // path that reaches here, so this is safe (portable-pty only requires
+    // the slave to outlive the child). Without this, the master never
+    // sees EOF and the PTY reader thread can block in read() forever,
+    // hanging the join below.
+    //
+    // Unix only, in effect: on Windows both handles refer to one
+    // refcounted ConPTY, so this releases a reference and closes nothing.
+    // See the watchdog below.
     drop(pair.slave);
 
     // Do NOT flip `running` before joining: a short-lived child (e.g.
@@ -405,13 +532,21 @@ pub fn run_script_mode(
     // Ctrl+C `running` is already false, keeping interrupts immediate.
     //
     // The drain must be bounded, though: an orphan that outlived the
-    // child (e.g. `ping example.com & exit`) holds the slave open and
-    // keeps writing, so EOF never comes. The watchdog flips the flag
-    // after a grace period and the reader stops at its next read.
+    // child (e.g. `ping example.com & exit`) holds the slave open, so EOF
+    // never comes. After a grace period the watchdog gives up on each
+    // platform's terms. `running` is what stops a Unix reader, which
+    // reaches the flag between bounded waits. Dropping the master is the
+    // only lever on a Windows one: it is the last reference to the
+    // pseudoconsole, and closing that releases the pipe the reader is
+    // parked on. The resize loop above was the master's only user, and
+    // the reader holds its own descriptors, so this costs Unix nothing.
+    // Dropped before the flag, so whatever the close shakes loose is
+    // still something the reader will relay.
     let drain_watchdog = {
         let running = running.clone();
         thread::spawn(move || {
             thread::sleep(Duration::from_secs(2));
+            drop(master);
             running.store(false, Ordering::SeqCst);
         })
     };

--- a/src/cli/script.rs
+++ b/src/cli/script.rs
@@ -41,14 +41,14 @@ impl RawModeGuard {
             }
 
             let mut original: libc::termios = std::mem::zeroed();
-            if libc::tcgetattr(libc::STDIN_FILENO, &mut original) != 0 {
+            if libc::tcgetattr(libc::STDIN_FILENO, &raw mut original) != 0 {
                 return Self { original: None };
             }
 
-            let mut raw = original;
-            libc::cfmakeraw(&mut raw);
+            let mut raw_mode = original;
+            libc::cfmakeraw(&raw mut raw_mode);
 
-            if libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, &raw) != 0 {
+            if libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, &raw const raw_mode) != 0 {
                 return Self { original: None };
             }
 


### PR DESCRIPTION
Chasing the E2E break in #198 turned up two more real hangs/races. Both are user-visible, not just CI noise. **Not for merge** — yours to land when you're happy.

Three commits, each independently coherent.

---

## 1. `build:` — declare the MSRV the graph actually requires

`rust-version = "1.75"` had not been true for a while: `idna`, via `url` → `reqwest`, pulls `icu_*` 2.x, which declares **1.86**. Nothing caught it, because CI builds on stable — so anyone on 1.75–1.85 got a compile error out of rustc rather than cargo's clean "requires a newer rustc".

Declaring the real floor also let clippy apply lints it had been holding back — `borrow_as_ptr` on the pre-existing raw-mode guard. `&raw` says what those always meant: take a pointer, without a reference to the terminal settings existing even briefly.

Fixing the number without fixing the mechanism would just let it rot again on the next `icu` bump, so there's now an `msrv` job that reads `rust-version` out of `Cargo.toml` and builds against exactly that toolchain. It passes, which makes 1.86 verified rather than asserted — the first time this claim has been checked at all.

## 2. `fix:` — a silent orphan hangs the client

```
shellshare exec -- sh -c 'trap "" HUP; (trap "" HUP; sleep 600) & exit 3'
  -> rc=137 (SIGKILL), no {"event":"end"}, immune to SIGTERM
```
Plain `shellshare` hangs the same way when you leave a quiet background job and exit the shell.

The command exiting isn't the end of its terminal — anything it left running holds the slave open, so the master never reaches EOF and the reader sits in `read()`. The drain watchdog was meant to bound that, but it only flips a flag, and a thread parked in a blocking read never returns to the top of the loop to see it.

Worth being precise, because the old comment wasn't wrong about the case it named: `ping example.com & exit` *does* work — a chatty orphan's writes keep returning from `read()`. **Silence** is what it never survived.

| case | before | after |
|---|---|---|
| silent HUP-immune orphan | rc=137, killed at 12s, no `end` | **rc=3, 2.1s** |
| interactive TTY, `sleep 60 &` then `exit` | hangs >20s | 2.1s |
| chatty orphan | 2057ms | 2064ms (no regression) |
| `seq 1 50000` room snapshot | — | byte-identical |
| 1.4MB through the PTY | 451/484/514/483ms | 492/478/492/490ms |

Fix: bounded `poll` before each read. **Windows** gets the same bound via its only lever — master and slave are two `Arc`s over one refcounted ConPTY (`portable-pty` `win/conpty.rs:26-38`), so `drop(pair.slave)` releases *nothing*; the old comment claiming otherwise was wrong.

Bounding the wait also meant no longer discarding what it collected: the sender thread broke wherever it stood when the flag dropped, and `shutdown` only flushes what already reached the transport. It now waits (deadlined) for the reader's last chunk instead of racing it.

New e2e test pins exit code, a deadline the old code blows through, a well-formed final JSON event, and pre-orphan output surviving the drain both locally and in the room. Verified it fails on the old binary.

One honest gap: the sender-side drain closes a measured ~50ms window (output reaches the room with it, is lost without it), and that window is *not* covered by the test — the marker is written at t≈0, far outside it. Hitting it would take output timed to land within ~20ms of the deadline, which is the kind of timing-dependent test CLAUDE.md says not to add. The reasoning and the measurement are in the code comment instead.

## 3. `refactor:` — drop the viewer's theme transition

The page chrome faded over 200ms on any theme change. But the theme is fixed when the broadcaster connects and stamped into every size message, so the only change a viewer reliably sees is *the default chrome becoming the broadcast's* — a repaint, not a change, which must not animate. A genuine re-theme needs a second broadcaster reclaiming the room while someone is still watching.

So the transition fired almost exclusively where it was wrong. And it did fire: the terminal is built from the webfont promise, which usually resolves before the first size message, so the paint that armed the transition was the *default* theme, and the real theme then washed in from the wrong colors. `test_page_chrome_follows_theme[light]` sampled that wash — **failing 5/5 locally**, intermittently on macOS CI. (My first framing of this as a rare flake was wrong; terminal-before-size is the normal ordering, and CI's Linux leg just happens to hit the other one.)

I did fix it first, and that is the argument for deleting it: the fix needed a second flag for "a size with usable dimensions has been seen", a third to keep arming idempotent across the two paths that can complete the pair, a two-frame wait to keep the class out of the same style recalculation as the colors that scheduled it (one frame was measured still fading ~24% of loads), and a rule spanning `<html>` and `<body>`, since `<body>` is a centred column and the gutters would otherwise snap while the column faded. All to smooth a case nobody asked to see smoothed. Every theme lands in one step now, in every ordering, and there is nothing left to get the ordering wrong about.

The test's webfont stub went too — with no fade to catch, it was measurably inert (the test fails 5/5 with or without it when the repaint is dropped). Verified the test still fails if the repaint is removed, so it is not vacuous.

## Verification

`make lint` clean · full e2e **260/260** · both fixes confirmed to fail on the pre-fix binary · all 9 CI checks green, including both e2e legs, Windows, and the new `msrv` job.

Reviewed adversarially across several rounds (subagents + Codex CLI). Findings that changed the code along the way:

- **MSRV break**: `&raw mut` needs 1.82 while `Cargo.toml` said 1.75 — found independently by two reviewers, and the thread that led to commit 1.
- Poll descriptor acquired **before** `spawn_command`, so a failure can't strand a running child.
- `F_DUPFD_CLOEXEC` rather than `dup`, which drops the flag `portable-pty` sets.
- A non-`EINTR` poll failure ends the session, as a failing read always did, rather than falling through to an uninterruptible read or stalling the broadcast silently.
- Drain deadline checked on every pass, not just idle ones.
- The `.bin` assertion above, after a reviewer showed the sender-side drain had no test at all.
- A comment of mine that overstated what commit 3 deletes — `main` had one flag and one deferred frame, not the pile my own intermediate work had grown.
