### PR TITLE
fix: normalize invalid RGB in keyframes

### DIFF
--- a/e2e/test_keyframe.py
+++ b/e2e/test_keyframe.py
@@ -39,7 +39,8 @@ STATIC_MARKER = "DASHBOARD"
 # marker; this is the "base paint" a real TUI does once on startup.
 BASE_PAINT = (
     "\x1b[?1049h\x1b[2J\x1b[H"
-    "\x1b[1;1H+==== DASHBOARD ====+"
+    "\x1b[1;1H\x1b[38;2;137;180;250;48;2;24;24;37m"
+    "+==== DASHBOARD ====+\x1b[0m"
     "\x1b[2;1H| loading...        |"
     "\x1b[3;1H+===================+"
 )
@@ -120,6 +121,13 @@ def test_late_joiner_sees_static_chrome_of_long_running_tui(
         assert FIRST_COUNTER not in snapshot, (
             "history was not evicted - raise NUM_UPDATES "
             f"(snapshot head: {snapshot[:80]!r})"
+        )
+        assert "38;2;137;180;250" in snapshot, (
+            "the keyframe lost the base paint's truecolor"
+        )
+        assert "38:2:137:180:250" not in snapshot, (
+            "the keyframe kept avt's ambiguous RGB form, which xterm.js "
+            "reads shifted by one channel"
         )
 
         # Behavior under test: a freshly-loaded viewer renders the static

--- a/src/cli/screen.rs
+++ b/src/cli/screen.rs
@@ -90,7 +90,8 @@ impl Keyframer {
         }
         // avt uses the 8-bit CSI (U+009B); rewrite to the 7-bit `ESC [` form
         // that every terminal and xterm.js accept.
-        Some(dump.replace('\u{9b}', "\x1b[").into_bytes())
+        let dump = dump.replace('\u{9b}', "\x1b[");
+        Some(semicolon_sgr_params(&dump).into_bytes())
     }
 
     fn apply_resize(&mut self, size: TermSize) {
@@ -148,4 +149,38 @@ impl Keyframer {
             self.carry.clear();
         }
     }
+}
+
+/// avt writes truecolor as `38:2:R:G:B`, which T.416 does not allow: the
+/// color-space field is positional, not optional, so a reader following the
+/// spec takes G and B for R and G and defaults B to 0 - blue arrives as
+/// yellow-green. xterm.js follows the spec (xtermjs/xterm.js#5792 was closed
+/// as working-as-intended), so the emitter is what has to change.
+///
+/// The only colons avt puts inside an SGR are colors, and screen text can
+/// never contain an ESC, so rewriting every colon in a `...m` sequence is
+/// enough. A dump's trailing sequence can be unterminated - `Vt::dump`
+/// reproduces in-flight parser state - so the end of the dump terminates one
+/// too. A param that already spells the empty color space (`38:2::R:G:B`) is
+/// left alone: that form is valid, and flattening its `::` to `;;` would
+/// reintroduce the very shift this removes.
+fn semicolon_sgr_params(dump: &str) -> String {
+    let mut out = String::with_capacity(dump.len());
+    let mut rest = dump;
+    while let Some(start) = rest.find("\x1b[") {
+        let (head, body) = rest.split_at(start + 2);
+        out.push_str(head);
+        let end = body
+            .find(|c: char| !matches!(c, '0'..='9' | ';' | ':'))
+            .unwrap_or(body.len());
+        let (params, tail) = body.split_at(end);
+        if (tail.starts_with('m') || tail.is_empty()) && !params.contains("::") {
+            out.push_str(&params.replace(':', ";"));
+        } else {
+            out.push_str(params);
+        }
+        rest = tail;
+    }
+    out.push_str(rest);
+    out
 }


### PR DESCRIPTION
## Summary

- normalize avt's ambiguous colon RGB parameters where keyframes are generated
- cover the spelling in the existing keyframe e2e test

## Root cause

avt serializes truecolor as `38:2:R:G:B` (`parser.rs:961` on main; `color.rs:16` in the pinned 0.16). T.416 does not allow that form: the color-space field is positional, not optional, so a reader following the spec takes G and B for R and G and defaults B to 0 - a periodic keyframe repaints an otherwise correct terminal in yellow-green.

avt's own parser accepts the form it emits (its tests parse `38:2:1:2:3` and `38:2::1:2:3` to the same color), so its dumps round-trip cleanly and the damage only appears in a real emulator. It is still present on avt main, so upgrading would not fix it - worth reporting upstream separately.

**xterm.js is not the place to fix this.** [xtermjs/xterm.js#5792](https://github.com/xtermjs/xterm.js/issues/5792) reported exactly this and was closed as working-as-intended, citing T.416 and DEC STD 070: an omitted middle parameter must still be separated, so positions never shift with parameter count. Of the three spellings in the wild, `38;2;R;G;B` is non-conformant but universally supported, `38:2::R:G:B` is the only strictly correct one, and `38:2:R:G:B` - avt's - is simply invalid. The emitter is what has to change.

## Approach

The rewrite happens at the one place we generate those bytes. Two facts make it a three-line transform rather than a pattern match:

- screen text can never contain an ESC (avt's parser consumes control chars instead of storing them as cells), so a CSI-bounded scan cannot touch user text;
- the only colons avt puts inside an SGR are colors, so every colon in a `...m` run can become a semicolon. `38:5:N` folds to `38;5;N`, which is equally valid.

`Vt::dump()` also appends in-flight parser state as a *final-byte-less* CSI, so the end of the dump terminates a sequence too - otherwise a keyframe that fires mid-SGR ships an un-normalized trailing color.

Params that already spell the empty color space (`38:2::R:G:B`) pass through untouched, so if avt is fixed upstream to emit the valid colon form, bumping the dependency does not silently re-break the colors by flattening `::` into `;;`.

## Deliberately not fixed in the viewer

An earlier revision of this PR also rewrote SGR in `room.js` for already-released broadcasters. Dropped after review:

- the viewer cannot distinguish an old broadcaster's keyframe from any application's live output, so it rewrote every session's bytes - contradicting "raw bytes end to end";
- measured ~4.1 ms per 31 KB colored frame, synchronous in `onmessage`/the decrypt chain (~130 ms block on a 1 MB history replay); the `indexOf(0x1b)` fast path misses on essentially every TUI frame;
- the bounded carry needed for split CSIs silently gave up past its cap, passing through exactly the ambiguous form it existed to fix;
- and it could not fix the unterminated trailing CSI at all, since its regex needs the closing `m`.

Trade-off: released binaries in the wild keep emitting the ambiguous form, so their keyframes stay miscolored for late joiners until the user upgrades. Cosmetic, self-healing on upgrade, and not worth a permanent per-frame cost on every viewer.

## Testing

- `cargo clippy --all-targets` clean
- normalizer verified against real `avt::Vt` dumps: fg/bg RGB normalized, `38:5:196` folded, literal screen text `HI 38:2:1:2:3` untouched, unterminated trailing CSI normalized
- normalizer also verified to leave the valid `38:2::R:G:B` form byte-for-byte unchanged
- full e2e suite: 259 passed

Fixes #189
